### PR TITLE
Removendo dependências para commons-lang

### DIFF
--- a/stella-boleto/pom.xml
+++ b/stella-boleto/pom.xml
@@ -27,11 +27,6 @@
 	    </dependency>	
 
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.3</version>
-		</dependency>
-		<dependency>
 			<groupId>pdfbox</groupId>
 			<artifactId>pdfbox</artifactId>
 			<version>0.7.3</version>

--- a/stella-boleto/src/main/java/br/com/caelum/stella/boleto/Boleto.java
+++ b/stella-boleto/src/main/java/br/com/caelum/stella/boleto/Boleto.java
@@ -6,8 +6,6 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
-
 import br.com.caelum.stella.boleto.exception.CriacaoBoletoException;
 
 /**
@@ -363,9 +361,9 @@ public class Boleto {
 	 * @return número do documento formatado (com 4 digitos)
 	 */
 	public String getNumeroDoDocumentoFormatado() {
-		return StringUtils.leftPad(this.numeroDocumento, 4, '0');
+		return String.format("%04d", new Integer(this.numeroDocumento));
 	}
-
+	
 	/**
 	 * @return agencia e codigo cedente (conta corrente) do banco
 	 */

--- a/stella-boleto/src/main/java/br/com/caelum/stella/boleto/transformer/PNGPDFTransformerHelper.java
+++ b/stella-boleto/src/main/java/br/com/caelum/stella/boleto/transformer/PNGPDFTransformerHelper.java
@@ -8,8 +8,6 @@ import java.util.Calendar;
 
 import javax.imageio.ImageIO;
 
-import org.apache.commons.lang.StringUtils;
-
 import br.com.caelum.stella.boleto.Boleto;
 import br.com.caelum.stella.boleto.bancos.GeradorDeLinhaDigitavel;
 import br.com.caelum.stella.boleto.exception.CriacaoBoletoException;
@@ -112,7 +110,7 @@ class PNGPDFTransformerHelper {
 		final float LINHA3 = 378;
 		
 		this.writer.write(50, LINHA1, boleto.getEmissor().getCedente());
-		this.writer.write(50, LINHA_ENDERECO_CEDENTE, StringUtils.defaultString(boleto.getEmissor().getEndereco()));
+		this.writer.write(50, LINHA_ENDERECO_CEDENTE, nullToEmpty(boleto.getEmissor().getEndereco()));
 		
 		this.writer.write(5, LINHA2, boleto.getSacado().getNome());
 		this.writer.write(290, LINHA2, formatDate(boleto.getDatas().getVencimento()));
@@ -176,7 +174,7 @@ class PNGPDFTransformerHelper {
 		final float LINHA_ENDERECO = 122;
 
 		this.writer.write(5, LINHA10, boleto.getEmissor().getCedente());
-		this.writer.write(5, LINHA_ENDERECO, StringUtils.defaultString(boleto.getEmissor().getEndereco()));
+		this.writer.write(5, LINHA_ENDERECO, nullToEmpty(boleto.getEmissor().getEndereco()));
 	}
 
 	private void imprimeDadosDoSacado(Boleto boleto) {
@@ -206,6 +204,10 @@ class PNGPDFTransformerHelper {
 		} catch (IOException e) {
 			throw new CriacaoBoletoException("Erro na geração do código de barras", e);
 		}
+	}
+	
+	private String nullToEmpty(String str) {
+	    return str == null ? "" : str;
 	}
 }
 


### PR DESCRIPTION
Com este commit é possível manter o commons-lang como optional. 

Haviam apenas dois métodos usados que poderiam ser facilmente substituídos por códigos da API padrão Java como <code>String.format</code> e um método útil <code>nullToEmpty</code> semelhante ao Guava.
