### PR TITLE
Garantindo acesso thread-safe nas formatações de data/number

### DIFF
--- a/stella-boleto/src/main/java/br/com/caelum/stella/boleto/transformer/FormatadorDeBoleto.java
+++ b/stella-boleto/src/main/java/br/com/caelum/stella/boleto/transformer/FormatadorDeBoleto.java
@@ -7,21 +7,25 @@ import java.util.Locale;
 
 class FormatadorDeBoleto {
 
-	private static NumberFormat formatador = NumberFormat
+	private static NumberFormat nfmt = NumberFormat
 			.getNumberInstance(new Locale("pt", "BR"));
 	
-	private static SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy"); 
+	private static SimpleDateFormat dfmt = new SimpleDateFormat("dd/MM/yyyy"); 
 	
 	static {
-		formatador.setMinimumFractionDigits(2);
-		formatador.setMaximumFractionDigits(2);
+		nfmt.setMinimumFractionDigits(2);
+		nfmt.setMaximumFractionDigits(2);
 	}
 	
 	static String formataData(final Calendar data) {
-		return sdf.format(data.getTime());
+		synchronized (dfmt) {
+			return dfmt.format(data.getTime());
+		}
 	}
 
 	static String formataValor(final double valor) {
-		return formatador.format(valor);
+		synchronized (nfmt) {
+			return nfmt.format(valor);
+		}
 	}
 }

--- a/stella-boleto/src/test/java/br/com/caelum/stella/boleto/transformer/FormatadorDeBoletoThreadSafe.java
+++ b/stella-boleto/src/test/java/br/com/caelum/stella/boleto/transformer/FormatadorDeBoletoThreadSafe.java
@@ -1,0 +1,75 @@
+package br.com.caelum.stella.boleto.transformer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.Test;
+
+public class FormatadorDeBoletoThreadSafe {
+
+    @Test
+    public void deveFormatarDataComAcessoMultiplosThreads()
+        throws Exception {
+
+        int iterations = 500;
+        ExecutorService exec = Executors.newFixedThreadPool(4);
+        List<Future<String>> results = new ArrayList<Future<String>>();
+
+        for (int i = 0; i < iterations; i++) {
+            final int x = i;
+            results.add(exec.submit(new Callable<String>() {
+                public String call()
+                    throws Exception {
+                    Calendar c = Calendar.getInstance();
+                    c.add(Calendar.MONTH, x);
+                    return FormatadorDeBoleto.formataData(c);
+                }
+            }));
+        }
+        exec.shutdown();
+
+        assertEquals(iterations, contarValoresUnicos(results));
+    }
+
+    @Test
+    public void deveFormatarDecimaisComAcessoMultiplosThreads()
+        throws Exception {
+
+        int iterations = 5000;
+        ExecutorService exec = Executors.newFixedThreadPool(4);
+        List<Future<String>> results = new ArrayList<Future<String>>();
+
+        for (int i = 0; i < iterations; i++) {
+            final int x = i;
+            final double v = new BigDecimal(x).doubleValue();
+            results.add(exec.submit(new Callable<String>() {
+                public String call()
+                    throws Exception {
+                    return FormatadorDeBoleto.formataValor(v);
+                }
+            }));
+        }
+        exec.shutdown();
+
+        assertEquals(iterations, contarValoresUnicos(results));
+    }
+
+    private int contarValoresUnicos(List<Future<String>> results)
+        throws Exception {
+        Set<String> values = new HashSet<String>();
+        for (Future<String> result : results) {
+            values.add(result.get());
+        }
+        return values.size();
+    }
+}


### PR DESCRIPTION
Pull request conforme discutido na lista caelum-stella-user. Os métodos de formatação de Date e Number precisam de acesso sincronizado, já que não são thread-safe.
