### PR TITLE
Corrige erro ao formatar nosso numero Santander

### DIFF
--- a/stella-boleto/src/main/java/br/com/caelum/stella/boleto/bancos/Santander.java
+++ b/stella-boleto/src/main/java/br/com/caelum/stella/boleto/bancos/Santander.java
@@ -50,7 +50,7 @@ public class Santander implements Banco {
 
 	@Override
 	public String getNossoNumeroDoEmissorFormatado(Emissor emissor) {
-		return String.format("%13d", emissor.getNossoNumero());
+		return String.format("%013d", emissor.getNossoNumero());
 	}
 
 	@Override

--- a/stella-boleto/src/test/java/br/com/caelum/stella/boleto/bancos/SantanderTest.java
+++ b/stella-boleto/src/test/java/br/com/caelum/stella/boleto/bancos/SantanderTest.java
@@ -1,7 +1,9 @@
 package br.com.caelum.stella.boleto.bancos;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -46,6 +48,16 @@ public class SantanderTest {
 	@Test
 	public void testGetImage() {
 		assertNotNull(banco.getImage());
+	}
+
+	@Test
+	public void testNossoNumeroDoEmissorFormatado() {
+		this.emissor = Emissor.novoEmissor().comCedente("BOTICARIO")
+				.comAgencia(6790).comDigitoAgencia('0').comCarteira(102)
+				.comContaCorrente(5260965l).comNossoNumero(123l);
+
+		assertThat(banco.getNossoNumeroDoEmissorFormatado(emissor),
+				is("0000000000123"));
 	}
 
 }


### PR DESCRIPTION
Ao gerar o boleto do Santander e informar o nosso número com menos de 13 dígitos, era para ser preenchido o resto do campo com 0 para a esquerda. Invés de acontecer isso, era preenchido com espaço e dava erro ao gerar o boleto pois era necessário um parse. O commit contem um teste para mostrar que o erro existe e a correção.
