### PR TITLE
Metodo para gerar o Dígito do Nosso Número do Santander

### DIFF
--- a/stella-boleto/src/main/java/br/com/caelum/stella/boleto/bancos/Santander.java
+++ b/stella-boleto/src/main/java/br/com/caelum/stella/boleto/bancos/Santander.java
@@ -86,7 +86,7 @@ public class Santander implements Banco {
 		return gdivSantander;
 	}
 	
-	public String calcularDigitoVerificador(Emissor emissor) {
+	public String calcularDigitoVerificadorNossoNumero(Emissor emissor) {
 		if (emissor == null || emissor.getNossoNumero() == null || emissor.getNossoNumero().length() > 12) {
 			throw new IllegalArgumentException();
 		}

--- a/stella-boleto/src/test/java/br/com/caelum/stella/boleto/bancos/SantanderTest.java
+++ b/stella-boleto/src/test/java/br/com/caelum/stella/boleto/bancos/SantanderTest.java
@@ -67,11 +67,11 @@ public class SantanderTest {
 	
 	@Test
 	public void testRetornarDigitoNossoNumero() throws Exception {
-		emissor.comNossoNumero("105613749501");
+		emissor.comNossoNumero("566612457800");
 		
-		String digito = banco.calcularDigitoVerificador(emissor);
+		String digito = banco.calcularDigitoVerificadorNossoNumero(emissor);
 		
-		assertThat(digito, is("4"));
+		assertThat(digito, is("2"));
 	}
 	
 	@Test
@@ -80,7 +80,7 @@ public class SantanderTest {
 		
 		emissor.comNossoNumero("1056137495014");
 		
-		banco.calcularDigitoVerificador(emissor);
+		banco.calcularDigitoVerificadorNossoNumero(emissor);
 	}
 	
 	@Test
@@ -89,14 +89,14 @@ public class SantanderTest {
 		
 		emissor.comNossoNumero(null);
 		
-		banco.calcularDigitoVerificador(emissor);
+		banco.calcularDigitoVerificadorNossoNumero(emissor);
 	}
 	
 	@Test
 	public void testRetornarDigitoQuandoNossoNumeroForMenorQueDoze() throws Exception {
 		emissor.comNossoNumero("1");
 		
-		String digito = banco.calcularDigitoVerificador(emissor);
+		String digito = banco.calcularDigitoVerificadorNossoNumero(emissor);
 		
 		assertThat(digito, is("9"));
 	}


### PR DESCRIPTION
Para a validação do boleto, é imprescindível utilizar o dígito do Nosso Número correto. Baseado na documentação do Santander (mais precisamente na página 13), foi criado um método para a geração do mesmo e seus respectivos testes, facilitando quem queira utilizar boletos do Santander.
