### PR TITLE
Corrigir leftPadWithZeros ao enviar valores nulos

### DIFF
--- a/stella-boleto/src/main/java/br/com/caelum/stella/boleto/utils/StellaStringUtils.java
+++ b/stella-boleto/src/main/java/br/com/caelum/stella/boleto/utils/StellaStringUtils.java
@@ -5,6 +5,10 @@ public class StellaStringUtils {
 	private static final String ZERO = "0";
 	
 	public static String leftPadWithZeros(String input, int expectedSize){
+		if( input == null ) {
+			return leftPadWithZeros("", expectedSize);
+		}
+		
 		StringBuilder sb = new StringBuilder(expectedSize);
 		
 		for (int i = expectedSize - input.length(); i>0; i-- ){

--- a/stella-boleto/src/test/java/br/com/caelum/stella/boleto/utils/StellaStringUtilsTest.java
+++ b/stella-boleto/src/test/java/br/com/caelum/stella/boleto/utils/StellaStringUtilsTest.java
@@ -28,6 +28,12 @@ public class StellaStringUtilsTest {
 	}
 	
 	
+	@Test
+	public void deveCompletarUmaStringComZerosAEsquerdaQuandoValorForNulo() {
+		String value = null;
+		String result = StellaStringUtils.leftPadWithZeros(value, 5);
+		assertEquals("00000", result);
+	}
 	
 
 }


### PR DESCRIPTION
Quando geramos um boleto, as vezes o método leftPadWithZeros é chamado em alguns campos que não são obrigatórios para a criação do mesmo. Com essa solução, evitamos um NullPointerException nesses casos. Contem também um teste mostrando o problema.
