### PR TITLE
Utilizar Digito do Nosso Numero no Santander

### DIFF
--- a/stella-boleto/src/main/java/br/com/caelum/stella/boleto/bancos/Santander.java
+++ b/stella-boleto/src/main/java/br/com/caelum/stella/boleto/bancos/Santander.java
@@ -52,6 +52,9 @@ public class Santander implements Banco {
 
 	@Override
 	public String getNossoNumeroDoEmissorFormatado(Emissor emissor) {
+		if (emissor.getDigitoNossoNumero() != null) {
+			return leftPadWithZeros(emissor.getNossoNumero()+emissor.getDigitoNossoNumero(), 13);
+		}
 		return leftPadWithZeros(emissor.getNossoNumero(), 13);
 	}
 

--- a/stella-boleto/src/test/java/br/com/caelum/stella/boleto/bancos/SantanderTest.java
+++ b/stella-boleto/src/test/java/br/com/caelum/stella/boleto/bancos/SantanderTest.java
@@ -59,21 +59,30 @@ public class SantanderTest {
 	public void testNossoNumeroDoEmissorFormatado() {
 		this.emissor = Emissor.novoEmissor().comCedente("BOTICARIO")
 				.comAgencia("6790").comDigitoAgencia("0").comCarteira("102")
-				.comContaCorrente("5260965").comNossoNumero("123");
+				.comContaCorrente("5260965").comNossoNumero("12").comDigitoNossoNumero("4");
 
 		assertThat(banco.getNossoNumeroDoEmissorFormatado(emissor),
-				is("0000000000123"));
+				is("0000000000124"));
 	}
 	
 	@Test
 	public void testUtilizarNumeroConvenio() throws Exception {
 		this.emissor = Emissor.novoEmissor().comCedente("BOTICARIO")
 				.comNumeroConvenio("3903125").comCarteira("102")
-				.comNossoNumero("3827130004722");
+				.comNossoNumero("382713000472").comDigitoNossoNumero("2");
 		boleto.comEmissor(emissor);
 		
 		assertThat(banco.geraCodigoDeBarrasPara(boleto),
 				is("03391569200000219509390312538271300047220102"));
+	}
+	
+	@Test
+	public void testUtilizarDigitoNossoNumero() throws Exception {
+		this.emissor = Emissor.novoEmissor().comCedente("BOTICARIO")
+				.comNumeroConvenio("3903125").comCarteira("102")
+				.comNossoNumero("382713000472").comDigitoNossoNumero("2");
+		
+		assertThat(banco.getNossoNumeroDoEmissorFormatado(emissor), is("3827130004722"));
 	}
 	
 	@Test	


### PR DESCRIPTION
Verifiquei que na classe Santander, o digito do nosso numero era utilizado apenas para aparecer no boleto, não havia uma lógica utilizando ele para a geração do código de barras. Na lógica antiga, o cálculo era feito corretamente, mas devíamos inserir o dígito verificador no campo do Nosso Numero. 
O Nosso Numero deve ter obrigatoriamente 12 dígitos, podemos ver que no método getNossoNumeroDoEmissorFormatado apenas o Nosso Numero é utilizado, deixando o dígito verificador de lado. O dígito verificador é essencial para a homologação correta do código de barras do boleto no caso do Santander. 
Nessa versão, quem ainda coloca o dígito no nosso numero não vai ter problemas, mas quem quiser utilizar os campos do Stella da maneira correta, não vai ter problemas também. Estou enviando também um teste que mostra o problema e algumas correções nos outros testes utilizando a solução.
