### PR TITLE
Utilizar calculo de DV do nosso numero em boletos santander

### DIFF
--- a/stella-boleto/src/main/java/br/com/caelum/stella/boleto/bancos/Santander.java
+++ b/stella-boleto/src/main/java/br/com/caelum/stella/boleto/bancos/Santander.java
@@ -1,13 +1,13 @@
 package br.com.caelum.stella.boleto.bancos;
 
+import static br.com.caelum.stella.boleto.utils.StellaStringUtils.leftPadWithZeros;
+
 import java.net.URL;
 
 import br.com.caelum.stella.boleto.Banco;
 import br.com.caelum.stella.boleto.Beneficiario;
 import br.com.caelum.stella.boleto.Boleto;
-import br.com.caelum.stella.boleto.bancos.gerador.GeradorDeDigito;
 import br.com.caelum.stella.boleto.bancos.gerador.GeradorDeDigitoSantander;
-import static br.com.caelum.stella.boleto.utils.StellaStringUtils.leftPadWithZeros;
 
 public class Santander implements Banco {
 
@@ -15,7 +15,7 @@ public class Santander implements Banco {
 
 	private final static String NUMERO_SANTANDER = "033";
 	private final static String DIGITO_SANTANDER = "7";
-	private GeradorDeDigito gdivSantander = new GeradorDeDigitoSantander();
+	private GeradorDeDigitoSantander gdivSantander = new GeradorDeDigitoSantander();
 
 	@Override
 	public String geraCodigoDeBarrasPara(Boleto boleto) {
@@ -51,10 +51,11 @@ public class Santander implements Banco {
 
 	@Override
 	public String getNossoNumeroFormatado(Beneficiario beneficiario) {
+		String nossoNumero = beneficiario.getNossoNumero();
 		if (beneficiario.getDigitoNossoNumero() != null) {
-			return leftPadWithZeros(beneficiario.getNossoNumero()+beneficiario.getDigitoNossoNumero(), 13);
-		}
-		return leftPadWithZeros(beneficiario.getNossoNumero(), 13);
+			return leftPadWithZeros(nossoNumero+beneficiario.getDigitoNossoNumero(), 13);
+		} 
+		return leftPadWithZeros(nossoNumero+getGeradorDeDigito().calculaDVNossoNumero(nossoNumero), 13);
 	}
 
 	@Override
@@ -84,7 +85,7 @@ public class Santander implements Banco {
 	}
  
 	@Override
-	public GeradorDeDigito getGeradorDeDigito() {
+	public GeradorDeDigitoSantander getGeradorDeDigito() {
 		return gdivSantander;
 	}
 	

--- a/stella-boleto/src/main/java/br/com/caelum/stella/boleto/bancos/gerador/GeradorDeDigitoSantander.java
+++ b/stella-boleto/src/main/java/br/com/caelum/stella/boleto/bancos/gerador/GeradorDeDigitoSantander.java
@@ -1,5 +1,8 @@
 package br.com.caelum.stella.boleto.bancos.gerador;
 
+import br.com.caelum.stella.DigitoPara;
+import static br.com.caelum.stella.boleto.utils.StellaStringUtils.leftPadWithZeros;
+
 public class GeradorDeDigitoSantander extends GeradorDeDigitoPadrao {
 
 	private static final long serialVersionUID = 1L;
@@ -41,4 +44,23 @@ public class GeradorDeDigitoSantander extends GeradorDeDigitoPadrao {
 			return 10 - resto;
 		}
 	}
+	
+	public String calculaDVNossoNumero(String nossoNumero) {
+		if (nossoNumero == null ||  nossoNumero.length() > 12) {
+			throw new IllegalArgumentException("Nosso Número inválido: " + nossoNumero);
+		}
+		DigitoPara digitoPara = new DigitoPara(leftPadWithZeros(nossoNumero, 12));
+		int digito = Integer.parseInt(digitoPara.comMultiplicadoresDeAte(2,9)
+							.mod(11)
+							.trocandoPorSeEncontrar("0", 1)
+							.trocandoPorSeEncontrar("1", 10)
+							.calcula());
+		
+		if (digito > 1) {
+			digito = 11-digito;
+		}
+		
+		return String.valueOf(digito);
+	}
+
 }

--- a/stella-boleto/src/test/java/br/com/caelum/stella/boleto/bancos/SantanderTest.java
+++ b/stella-boleto/src/test/java/br/com/caelum/stella/boleto/bancos/SantanderTest.java
@@ -32,7 +32,8 @@ public class SantanderTest {
 
 	    this.beneficiario = Beneficiario.novoBeneficiario().comNomeBeneficiario("PETROBRAS")
             .comAgencia("6790").comDigitoAgencia("0").comCarteira("102")
-            .comNumeroConvenio("5260965").comNossoNumero("1056137495014");  
+            .comNumeroConvenio("5260965").comNossoNumero("105613749501")
+            .comDigitoNossoNumero("4");  
 
 	    Pagador pagador = Pagador.novoPagador().comNome("PAULO SILVEIRA") ; 
 	    
@@ -56,7 +57,7 @@ public class SantanderTest {
 	}
 
 	@Test
-	public void testNossoNumeroDoEmissorFormatado() {
+	public void testNossoNumeroDoBeneficiarioFormatado() {
 		this.beneficiario = Beneficiario.novoBeneficiario().comNomeBeneficiario("BOTICARIO")
 				.comAgencia("6790").comDigitoAgencia("0").comCarteira("102")
 				.comCodigoBeneficiario("5260965").comNossoNumero("12").comDigitoNossoNumero("4");
@@ -84,4 +85,63 @@ public class SantanderTest {
 		
 		assertThat(banco.getNossoNumeroFormatado(beneficiario), is("3827130004722"));
 	}
+	
+	@Test	
+	public void testRetornarDigitoNossoNumero() throws Exception {
+		String[][] parametros = { 
+				{ "566612457800", "2" },
+				{ "566612457801", "0" },
+				{ "566612457802", "9" },
+				{ "566612457803", "7" },
+				{ "566612457804", "5" },
+				{ "566612457810", "0" }
+		};
+
+		for (String[] parametro : parametros) {
+			String nossoNumero = parametro[0];
+			beneficiario.comNossoNumero(nossoNumero);
+			String digito = banco.getGeradorDeDigito().calculaDVNossoNumero(beneficiario.getNossoNumero());
+			String digitoEsperado = parametro[1];
+			assertThat("Para o nosso número " + nossoNumero, digito, is(digitoEsperado));
+		}
+	}
+	
+	@Test
+	public void testLancarExcecaoQuandoNossoNumeroForMaiorQueDoze() throws Exception {
+		excecao.expect(IllegalArgumentException.class);
+		beneficiario.comNossoNumero("1056137495014");
+		banco.getGeradorDeDigito().calculaDVNossoNumero(beneficiario.getNossoNumero());
+	}
+	
+	@Test
+	public void testLancarExcecaoQuandoNossoNumeroForNulo() throws Exception {
+		excecao.expect(IllegalArgumentException.class);
+		beneficiario.comNossoNumero(null);
+		banco.getGeradorDeDigito().calculaDVNossoNumero(beneficiario.getNossoNumero());
+	}
+	
+	@Test
+	public void testRetornarDigitoQuandoNossoNumeroForMenorQueDoze() throws Exception {
+		beneficiario.comNossoNumero("1");
+		String digito = banco.getGeradorDeDigito().calculaDVNossoNumero(beneficiario.getNossoNumero());
+		assertThat(digito, is("9"));
+	}
+	
+	@Test
+	public void testAdicionarDVNossoNumeroQuandoOMesmoEstaNulo() throws Exception {
+		String nossoNumero = "105613749501";
+		String dvNossoNumero = "4";
+		beneficiario.comNossoNumero(nossoNumero);
+		assertThat(nossoNumero+dvNossoNumero, is(banco.getNossoNumeroFormatado(beneficiario)));
+	}
+	
+	@Test
+	public void testAdicionarDVNossoNumeroQuandoOMesmoEstaPreenchido() throws Exception {
+		String nossoNumero = "566612457803";
+		String dvNossoNumero = "5";
+		beneficiario.comNossoNumero(nossoNumero);
+		beneficiario.comDigitoNossoNumero(dvNossoNumero);
+		assertThat(nossoNumero+dvNossoNumero, is(banco.getNossoNumeroFormatado(beneficiario)));
+	}
+
 }


### PR DESCRIPTION
Estou enviando esse pull request seguindo a discussão que houve no seguinte post do grupo:
https://groups.google.com/forum/#!topic/caelum-stella-user/JH2xCett4Kw
Com essas mudanças, caso não seja informado um DV, o método para calcular o DV do Nosso Numero é utilizado. Se for informado, o dígito informado será utilizado.
Os testes foram retornados e alguns foram adicionados para assegurar que não haverá falhas.
Vale reiterar que as mudanças são apenas para boletos do Santander.
