### PR TITLE
Update Estados.java

### DIFF
--- a/stella-nfe/src/main/java/br/com/caelum/stella/nfe/Estados.java
+++ b/stella-nfe/src/main/java/br/com/caelum/stella/nfe/Estados.java
@@ -1,16 +1,57 @@
 package br.com.caelum.stella.nfe;
 
+/**
+ * Enum que contém todos os estados brasileiros.
+ * @author Jerônimo Nunes Rocha
+ *
+ */
 public enum Estados {
 
-	SP("35");
-	
-	private final String codigo;
+	RO(11,"Rondônia"),
+	AC(12,"Acre"),
+	AM(13,"Amazonas"),
+	RR(14,"Roraima"),
+	PA(15,"Pará"),
+	AP(16,"Amapá"),
+	TO(17,"Tocantins"),
+	MA(21,"Maranhão"),
+	PI(22,"Piauí"),
+	CE(23,"Ceará"),
+	RN(24,"Rio Grande do Norte"),
+	PB(25,"Paraíba"),
+	PE(26,"Pernambuco"),
+	AL(27,"Alagoas"),
+	SE(28,"Sergipe"),
+	BA(29,"Bahia"),
+	MG(31,"Minas Gerais"),
+	ES(32,"Espírito Santo"),
+	RJ(33,"Rio de Janeiro"),
+	SP(35,"São Paulo"),
+	PR(41,"Paraná"),
+	SC(42,"Santa Catarina"),
+	RS(43,"Rio Grande do Sul"),
+	MS(50,"Mato Grosso do Sul"),
+	MT(51,"Mato Grosso"),
+	GO(52,"Goiás"),
+	DF(53,"Distrito Federal");
 
-	private Estados(String codigo) {
-		this.codigo = codigo;
+	private final int codigoIbge;
+	private final String nome;
+
+	private Estados(int codigoIbge,String nome) {
+		this.codigoIbge = codigoIbge;
+		this.nome = nome;
 	}
 	
 	public String getCodigo() {
-		return codigo;
+		return Integer.toString(codigoIbge);
+	}
+	
+	public String getNome(){
+		return nome;
+	}
+	
+	public int getCodigoIbge(){
+		return codigoIbge;
 	}
 }


### PR DESCRIPTION
Alterei o Enum de estados pois continha apenas São Paulo, agora contém todos os estados do Brasil. Só achei estranho o valor do Enum ser uma string com o código do IBGE ao invés de int, mudei para inteiro mas mantive a função antiga getCodigo para não quebrar compatibilidade e adicionei o nome do estado, que pode ser útil futuramente.
