### PR TITLE
- Validação de CNPJ nulo para evitar NullPointerException

### DIFF
--- a/stella-core/src/main/java/br/com/caelum/stella/validation/CNPJValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/CNPJValidator.java
@@ -118,6 +118,9 @@ public class CNPJValidator implements Validator<String> {
 	}
 
     public boolean isEligible(String value) {
+		if (value == null) {
+			return false;
+		}
         boolean result;
         if (isFormatted) {
             result = FORMATED.matcher(value).matches();

--- a/stella-core/src/test/java/br/com/caelum/stella/validation/CNPJValidatorTest.java
+++ b/stella-core/src/test/java/br/com/caelum/stella/validation/CNPJValidatorTest.java
@@ -148,6 +148,12 @@ public class CNPJValidatorTest {
     }
 
     @Test
+    public void shouldNotBeEligibleWithNullCNPJ() {
+        final CNPJValidator cnpjValidator = new CNPJValidator();
+        assertFalse(cnpjValidator.isEligible(null));
+    }
+    
+    @Test
     public void shouldBeEligibleDefaultConstructor() {
         final CNPJValidator cnpjValidator = new CNPJValidator();
         assertTrue(cnpjValidator.isEligible(validStringNotFormatted));


### PR DESCRIPTION
Ao utilizar método isEligible na classe CNPJValidator passando parâmetro nulo está lançando NullPointerException.
