### PR TITLE
Adiciona o conceito de regiões do território nacional

### DIFF
--- a/stella-core/src/main/java/br/com/caelum/stella/type/Estado.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/type/Estado.java
@@ -34,7 +34,7 @@ import br.com.caelum.stella.validation.ie.IETocantinsValidator;
  * Respresenta um estado brasileiro, ou o Destrito Federal.
  * 
  * @author leobessa
- * 
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
  */
 public enum Estado {
 
@@ -221,5 +221,32 @@ public enum Estado {
     
     public int getCodigoIBGE() {
 		return codigoIBGE;
+	}
+
+    /**
+	 * A região do território brasileiro em que esse estado está localizado.
+	 *
+	 * @return Retorna a região em que esse estado está localizado.
+	 */
+	public Regiao regiao() {
+		Regiao[] regioes = Regiao.values();
+
+		for (Regiao regiao : regioes) {
+			if(regiao.compostaPor(this)) {
+				return regiao;
+			}
+		}
+
+		throw new IllegalStateException("Não foi possível determinar a região do estado " + this);
+	}
+
+	/**
+	 * Verifica se esse estado está localizado na região informada.
+	 *
+	 * @param regiao Uma das regiões do território brasileiro.
+	 * @return Retorna {@code true} se esse estado pertencer à região informada ou {@code false} caso contrário.
+	 */
+	public boolean localizadoEm(Regiao regiao) {
+		return regiao() == regiao;
 	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/type/Regiao.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/type/Regiao.java
@@ -1,0 +1,78 @@
+package br.com.caelum.stella.type;
+
+import static br.com.caelum.stella.type.Estado.AC;
+import static br.com.caelum.stella.type.Estado.AL;
+import static br.com.caelum.stella.type.Estado.AM;
+import static br.com.caelum.stella.type.Estado.AP;
+import static br.com.caelum.stella.type.Estado.BA;
+import static br.com.caelum.stella.type.Estado.CE;
+import static br.com.caelum.stella.type.Estado.DF;
+import static br.com.caelum.stella.type.Estado.ES;
+import static br.com.caelum.stella.type.Estado.GO;
+import static br.com.caelum.stella.type.Estado.MA;
+import static br.com.caelum.stella.type.Estado.MG;
+import static br.com.caelum.stella.type.Estado.MS;
+import static br.com.caelum.stella.type.Estado.MT;
+import static br.com.caelum.stella.type.Estado.PA;
+import static br.com.caelum.stella.type.Estado.PB;
+import static br.com.caelum.stella.type.Estado.PE;
+import static br.com.caelum.stella.type.Estado.PI;
+import static br.com.caelum.stella.type.Estado.PR;
+import static br.com.caelum.stella.type.Estado.RJ;
+import static br.com.caelum.stella.type.Estado.RN;
+import static br.com.caelum.stella.type.Estado.RO;
+import static br.com.caelum.stella.type.Estado.RR;
+import static br.com.caelum.stella.type.Estado.RS;
+import static br.com.caelum.stella.type.Estado.SC;
+import static br.com.caelum.stella.type.Estado.SE;
+import static br.com.caelum.stella.type.Estado.SP;
+import static br.com.caelum.stella.type.Estado.TO;
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+/**
+ * Representa as divisões regionais do território brasileiro.
+ *
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ */
+public enum Regiao {
+	CENTRO_OESTE,
+	NORDESTE,
+	NORTE,
+	SUDESTE,
+	SUL;
+
+
+	/**
+	 * A lista de estados que compõem essa região.
+	 *
+	 * @return Retorna uma lista dos estados que compõem essa região.
+	 */
+	public List<Estado> estados() {
+		switch (this) {
+		case CENTRO_OESTE:
+			return asList(MT, MS, GO, DF);
+		case NORDESTE:
+			return asList(MA, PI, CE, RN, PE, PB, SE, AL, BA);
+		case NORTE:
+			return asList(AM, RR, AP, PA, TO, RO, AC);
+		case SUDESTE:
+			return asList(SP, RJ, ES, MG);
+		case SUL:
+			return asList(PR, RS, SC);
+		default:
+			throw new IllegalStateException("Não é possível determinar os estados que compõem a região " + this);
+		}
+	}
+
+	/**
+	 * Verifica se o estado informado faz parte dessa região.
+	 *
+	 * @param estado Um estado do território brasileiro.
+	 * @return Retorna {@code true} se o estado fizer parte dessa região ou {@code false} caso contrário.
+	 */
+	public boolean compostaPor(Estado estado) {
+		return estados().contains(estado);
+	}
+}

--- a/stella-core/src/main/java/br/com/caelum/stella/type/Regiao.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/type/Regiao.java
@@ -1,9 +1,8 @@
 package br.com.caelum.stella.type;
 
 import static br.com.caelum.stella.type.Estado.*;
-import static java.util.Arrays.asList;
 
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Set;
 
 /**
@@ -21,7 +20,7 @@ public enum Regiao {
 	private final Set<Estado> estados;
 
 	private Regiao(Estado... estados) {
-		this.estados = new HashSet<Estado>(asList(estados));
+		this.estados = EnumSet.of(estados[0], estados);
 	}
 
 	/**

--- a/stella-core/src/main/java/br/com/caelum/stella/type/Regiao.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/type/Regiao.java
@@ -1,32 +1,6 @@
 package br.com.caelum.stella.type;
 
-import static br.com.caelum.stella.type.Estado.AC;
-import static br.com.caelum.stella.type.Estado.AL;
-import static br.com.caelum.stella.type.Estado.AM;
-import static br.com.caelum.stella.type.Estado.AP;
-import static br.com.caelum.stella.type.Estado.BA;
-import static br.com.caelum.stella.type.Estado.CE;
-import static br.com.caelum.stella.type.Estado.DF;
-import static br.com.caelum.stella.type.Estado.ES;
-import static br.com.caelum.stella.type.Estado.GO;
-import static br.com.caelum.stella.type.Estado.MA;
-import static br.com.caelum.stella.type.Estado.MG;
-import static br.com.caelum.stella.type.Estado.MS;
-import static br.com.caelum.stella.type.Estado.MT;
-import static br.com.caelum.stella.type.Estado.PA;
-import static br.com.caelum.stella.type.Estado.PB;
-import static br.com.caelum.stella.type.Estado.PE;
-import static br.com.caelum.stella.type.Estado.PI;
-import static br.com.caelum.stella.type.Estado.PR;
-import static br.com.caelum.stella.type.Estado.RJ;
-import static br.com.caelum.stella.type.Estado.RN;
-import static br.com.caelum.stella.type.Estado.RO;
-import static br.com.caelum.stella.type.Estado.RR;
-import static br.com.caelum.stella.type.Estado.RS;
-import static br.com.caelum.stella.type.Estado.SC;
-import static br.com.caelum.stella.type.Estado.SE;
-import static br.com.caelum.stella.type.Estado.SP;
-import static br.com.caelum.stella.type.Estado.TO;
+import static br.com.caelum.stella.type.Estado.*;
 import static java.util.Arrays.asList;
 
 import java.util.List;

--- a/stella-core/src/main/java/br/com/caelum/stella/type/Regiao.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/type/Regiao.java
@@ -3,7 +3,8 @@ package br.com.caelum.stella.type;
 import static br.com.caelum.stella.type.Estado.*;
 import static java.util.Arrays.asList;
 
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Representa as divisões regionais do território brasileiro.
@@ -11,33 +12,25 @@ import java.util.List;
  * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
  */
 public enum Regiao {
-	CENTRO_OESTE,
-	NORDESTE,
-	NORTE,
-	SUDESTE,
-	SUL;
+	CENTRO_OESTE(DF, GO, MT, MS),
+	NORDESTE(AL, BA, CE, MA, PB, PE, PI, RN, SE),
+	NORTE(AC, AM, AP, PA, RO, RR, TO),
+	SUDESTE(ES, MG, RJ, SP),
+	SUL(PR, RS, SC);
 
+	private final Set<Estado> estados;
+
+	private Regiao(Estado... estados) {
+		this.estados = new HashSet<Estado>(asList(estados));
+	}
 
 	/**
 	 * A lista de estados que compõem essa região.
 	 *
 	 * @return Retorna uma lista dos estados que compõem essa região.
 	 */
-	public List<Estado> estados() {
-		switch (this) {
-		case CENTRO_OESTE:
-			return asList(MT, MS, GO, DF);
-		case NORDESTE:
-			return asList(MA, PI, CE, RN, PE, PB, SE, AL, BA);
-		case NORTE:
-			return asList(AM, RR, AP, PA, TO, RO, AC);
-		case SUDESTE:
-			return asList(SP, RJ, ES, MG);
-		case SUL:
-			return asList(PR, RS, SC);
-		default:
-			throw new IllegalStateException("Não é possível determinar os estados que compõem a região " + this);
-		}
+	public Set<Estado> estados() {
+		return estados;
 	}
 
 	/**

--- a/stella-core/src/test/java/br/com/caelum/stella/type/EstadoTest.java
+++ b/stella-core/src/test/java/br/com/caelum/stella/type/EstadoTest.java
@@ -1,0 +1,60 @@
+package br.com.caelum.stella.type;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ */
+public class EstadoTest {
+	@Test
+	public void regionsOfStates() throws Exception {
+		assertThat(Estado.AC.regiao(), is(Regiao.NORTE));
+		assertThat(Estado.AL.regiao(), is(Regiao.NORDESTE));
+		assertThat(Estado.AM.regiao(), is(Regiao.NORTE));
+		assertThat(Estado.AP.regiao(), is(Regiao.NORTE));
+		assertThat(Estado.BA.regiao(), is(Regiao.NORDESTE));
+		assertThat(Estado.CE.regiao(), is(Regiao.NORDESTE));
+		assertThat(Estado.DF.regiao(), is(Regiao.CENTRO_OESTE));
+		assertThat(Estado.ES.regiao(), is(Regiao.SUDESTE));
+		assertThat(Estado.GO.regiao(), is(Regiao.CENTRO_OESTE));
+		assertThat(Estado.MA.regiao(), is(Regiao.NORDESTE));
+		assertThat(Estado.MG.regiao(), is(Regiao.SUDESTE));
+		assertThat(Estado.MS.regiao(), is(Regiao.CENTRO_OESTE));
+		assertThat(Estado.MT.regiao(), is(Regiao.CENTRO_OESTE));
+		assertThat(Estado.PA.regiao(), is(Regiao.NORTE));
+		assertThat(Estado.PB.regiao(), is(Regiao.NORDESTE));
+		assertThat(Estado.PE.regiao(), is(Regiao.NORDESTE));
+		assertThat(Estado.PI.regiao(), is(Regiao.NORDESTE));
+		assertThat(Estado.PR.regiao(), is(Regiao.SUL));
+		assertThat(Estado.RJ.regiao(), is(Regiao.SUDESTE));
+		assertThat(Estado.RN.regiao(), is(Regiao.NORDESTE));
+		assertThat(Estado.RO.regiao(), is(Regiao.NORTE));
+		assertThat(Estado.RR.regiao(), is(Regiao.NORTE));
+		assertThat(Estado.RS.regiao(), is(Regiao.SUL));
+		assertThat(Estado.SC.regiao(), is(Regiao.SUL));
+		assertThat(Estado.SE.regiao(), is(Regiao.NORDESTE));
+		assertThat(Estado.SP.regiao(), is(Regiao.SUDESTE));
+		assertThat(Estado.TO.regiao(), is(Regiao.NORTE));
+	}
+
+	@Test
+	public void statesAreLocatedInTheirRegions() throws Exception {
+		for (Estado state : Estado.values()) {
+			assertThat("O estado " + state + " está localizada na região " + state.regiao(), state.localizadoEm(state.regiao()), is(true));
+		}
+	}
+
+	@Test
+	public void statesAreNotLocatedInOtherRegions() throws Exception {
+		for (Estado state : Estado.values()) {
+			for (Regiao region : Regiao.values()) {
+				if(state.regiao() != region) {
+					assertThat("O estado " + state + " não está localizado na região " + region, state.localizadoEm(region), is(false));
+				}
+			}
+		}
+	}
+}

--- a/stella-core/src/test/java/br/com/caelum/stella/type/RegiaoTest.java
+++ b/stella-core/src/test/java/br/com/caelum/stella/type/RegiaoTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -14,7 +14,7 @@ import org.junit.Test;
 public class RegiaoTest {
 	@Test
 	public void statesOfSouthRegion() throws Exception {
-		List<Estado> estados = Regiao.SUL.estados();
+		Set<Estado> estados = Regiao.SUL.estados();
 
 		assertThat(estados.size(), is(3));
 		assertThat(estados, hasItems(Estado.PR, Estado.RS, Estado.SC));
@@ -22,7 +22,7 @@ public class RegiaoTest {
 
 	@Test
 	public void statesOfSoutheastRegion() throws Exception {
-		List<Estado> estados = Regiao.SUDESTE.estados();
+		Set<Estado> estados = Regiao.SUDESTE.estados();
 
 		assertThat(estados.size(), is(4));
 		assertThat(estados, hasItems(Estado.SP, Estado.RJ, Estado.ES, Estado.MG));
@@ -30,7 +30,7 @@ public class RegiaoTest {
 
 	@Test
 	public void statesOfMidWestRegion() throws Exception {
-		List<Estado> estados = Regiao.CENTRO_OESTE.estados();
+		Set<Estado> estados = Regiao.CENTRO_OESTE.estados();
 
 		assertThat(estados.size(), is(4));
 		assertThat(estados, hasItems(Estado.MT, Estado.MS, Estado.GO, Estado.DF));
@@ -38,7 +38,7 @@ public class RegiaoTest {
 
 	@Test
 	public void statesOfNortheastRegion() throws Exception {
-		List<Estado> estados = Regiao.NORDESTE.estados();
+		Set<Estado> estados = Regiao.NORDESTE.estados();
 
 		assertThat(estados.size(), is(9));
 		assertThat(estados, hasItems(Estado.MA, Estado.PI, Estado.CE, Estado.RN, Estado.PE, Estado.PB, Estado.SE, Estado.AL, Estado.BA));
@@ -46,7 +46,7 @@ public class RegiaoTest {
 
 	@Test
 	public void statesOfNorthRegion() throws Exception {
-		List<Estado> estados = Regiao.NORTE.estados();
+		Set<Estado> estados = Regiao.NORTE.estados();
 
 		assertThat(estados.size(), is(7));
 		assertThat(estados, hasItems(Estado.AM, Estado.RR, Estado.AP, Estado.PA, Estado.TO, Estado.RO, Estado.AC));

--- a/stella-core/src/test/java/br/com/caelum/stella/type/RegiaoTest.java
+++ b/stella-core/src/test/java/br/com/caelum/stella/type/RegiaoTest.java
@@ -1,0 +1,79 @@
+package br.com.caelum.stella.type;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ */
+public class RegiaoTest {
+	@Test
+	public void statesOfSouthRegion() throws Exception {
+		List<Estado> estados = Regiao.SUL.estados();
+
+		assertThat(estados.size(), is(3));
+		assertThat(estados, hasItems(Estado.PR, Estado.RS, Estado.SC));
+	}
+
+	@Test
+	public void statesOfSoutheastRegion() throws Exception {
+		List<Estado> estados = Regiao.SUDESTE.estados();
+
+		assertThat(estados.size(), is(4));
+		assertThat(estados, hasItems(Estado.SP, Estado.RJ, Estado.ES, Estado.MG));
+	}
+
+	@Test
+	public void statesOfMidWestRegion() throws Exception {
+		List<Estado> estados = Regiao.CENTRO_OESTE.estados();
+
+		assertThat(estados.size(), is(4));
+		assertThat(estados, hasItems(Estado.MT, Estado.MS, Estado.GO, Estado.DF));
+	}
+
+	@Test
+	public void statesOfNortheastRegion() throws Exception {
+		List<Estado> estados = Regiao.NORDESTE.estados();
+
+		assertThat(estados.size(), is(9));
+		assertThat(estados, hasItems(Estado.MA, Estado.PI, Estado.CE, Estado.RN, Estado.PE, Estado.PB, Estado.SE, Estado.AL, Estado.BA));
+	}
+
+	@Test
+	public void statesOfNorthRegion() throws Exception {
+		List<Estado> estados = Regiao.NORTE.estados();
+
+		assertThat(estados.size(), is(7));
+		assertThat(estados, hasItems(Estado.AM, Estado.RR, Estado.AP, Estado.PA, Estado.TO, Estado.RO, Estado.AC));
+	}
+
+	@Test
+	public void regionsAreComposedOfTheirOwnStates() throws Exception {
+		Regiao[] regions = Regiao.values();
+
+		for (Regiao region : regions) {
+			for (Estado state : region.estados()) {
+				assertThat("O estado " + state + " faz parte da região " + region, region.compostaPor(state), is(true));
+			}
+		}
+	}
+
+	@Test
+	public void regionIsNotComposedOfStatesFromOtherRegions() throws Exception {
+		Estado[] states = Estado.values();
+		Regiao[] regions = Regiao.values();
+
+		for (Estado state : states) {
+			for (Regiao region : regions) {
+				if(state.regiao() != region) {
+					assertThat("O estado " + state + " não faz parte da região " + region, region.compostaPor(state), is(false));
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Essa mudança adiciona um enum `Regiao` que representa o conjunto de 5 regiões em que se divide o território nacional: Norte, Nordeste, Centro Oeste, Sudeste e Sul. Cada região é composta por seus respectivos estados (+ o Distrito Federal). Dessa forma, o enum `Estado` também foi alterado para que cada estado saiba em que região está localizado.

Essa alteração permite que lógicas possam se basear no conceito de região, ao invés de obrigar o desenvolvedor a criar o seu próprio conjunto de estados. Os métodos `Regiao#compostaPor` e `Estado#localizadoEm` também facilitam a aplicação de lógicas que levam em consideração as regiões.

**Nota Técnica**
A amarração entre regiões e estados poderia ser feita na inicialização dos enums. Cada região teria o seu conjunto de estados e cada estado a sua região. Apesar de não causar um erro de compilação, essa situação gera um ciclo de interdependência na inicialização dos enums `Regiao` e `Estado`, causando resultados inesperados e indeterminados. Por isso, a amarração entre regiões e estados é feita dinamicamente nas chamadas dos métodos `Regiao#estados` e `Estado#regiao`.