### PR TITLE
Hibernate user types - compatibilidade com versões anteriores a 5.2.0

### DIFF
--- a/stella-hibernate-user-types/pom.xml
+++ b/stella-hibernate-user-types/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
-			<version>[4.0.1.Final,)</version>
+			<version>[4.0.1.Final,5.2.0-final)</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Corrige build quebrado no módulo stella-hibernate-user-types mencionado na issue #192.

No pom.xml do módulo estava indicando para obter alguma versão superior(sempre a última versão disponível) a 4.0.1.Final do Hibernate. Na versão 5.2.0 do Hibernate ocorreu alterações nas assinaturas dos métodos da interface UserType e consequentemente causando erros de compilação nas classes CepUserType e CpfUserType.
