### PR TITLE
DRY - refatoração em validadores de ie

### DIFF
--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/AbstractIEValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/AbstractIEValidator.java
@@ -1,8 +1,11 @@
 package br.com.caelum.stella.validation.ie;
 
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.MessageProducer;
 import br.com.caelum.stella.ValidationMessage;
@@ -12,7 +15,7 @@ import br.com.caelum.stella.validation.Validator;
 import br.com.caelum.stella.validation.error.IEError;
 
 public abstract class AbstractIEValidator implements Validator<String> {
-	
+
 	protected final boolean isFormatted;
 	private final BaseValidator baseValidator;
 
@@ -25,63 +28,76 @@ public abstract class AbstractIEValidator implements Validator<String> {
 		this.baseValidator = new BaseValidator();
 	}
 
-	public AbstractIEValidator(MessageProducer messageProducer,
-			boolean isFormatted) {
+	public AbstractIEValidator(MessageProducer messageProducer, boolean isFormatted) {
 		this.baseValidator = new BaseValidator(messageProducer);
 		this.isFormatted = isFormatted;
 	}
 
 	private List<InvalidValue> getInvalidValues(String IE) {
-	    List<InvalidValue> errors = new ArrayList<InvalidValue>();
-	    if (IE != null) {
-	        String unformattedIE = checkForCorrectFormat(IE, errors);
-	        if (errors.isEmpty()) {
-	            if (!hasValidCheckDigits(unformattedIE)) {
-	                errors.add(IEError.INVALID_CHECK_DIGITS);
-	            }
-	        }
-	    }
-	    return errors;
+		List<InvalidValue> errors = new ArrayList<InvalidValue>();
+		if (IE != null) {
+			String unformattedIE = checkForCorrectFormat(IE, errors);
+			if (errors.isEmpty()) {
+				if (!hasValidCheckDigits(unformattedIE)) {
+					errors.add(IEError.INVALID_CHECK_DIGITS);
+				}
+			}
+		}
+		return errors;
 	}
 
 	protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
-	    String unformatedIE = null;
-	    if (isFormatted) {
-	        if (!(getFormattedPattern().matcher(ie).matches())) {
-	            errors.add(IEError.INVALID_FORMAT);
-	        }
-	        unformatedIE = ie.replaceAll("\\D", "");
-	    } else {
-	        if (!getUnformattedPattern().matcher(ie).matches()) {
-	            errors.add(IEError.INVALID_DIGITS);
-	        }
-	        unformatedIE = ie;
-	    }
-	    return unformatedIE;
+		String unformatedIE = null;
+		if (isFormatted) {
+			if (!(getFormattedPattern().matcher(ie).matches())) {
+				errors.add(IEError.INVALID_FORMAT);
+			}
+			unformatedIE = ie.replaceAll("\\D", "");
+		} else {
+			if (!getUnformattedPattern().matcher(ie).matches()) {
+				errors.add(IEError.INVALID_DIGITS);
+			}
+			unformatedIE = ie;
+		}
+		return unformatedIE;
 	}
 
 	protected abstract Pattern getUnformattedPattern();
 
 	protected abstract Pattern getFormattedPattern();
-		
+
 	public boolean isEligible(String value) {
-	    boolean result;
-	    if (isFormatted) {
-	        result = getFormattedPattern().matcher(value).matches();
-	    } else {
-	        result = getUnformattedPattern().matcher(value).matches();
-	    }
-	    return result;
+		boolean result;
+		if (isFormatted) {
+			result = getFormattedPattern().matcher(value).matches();
+		} else {
+			result = getUnformattedPattern().matcher(value).matches();
+		}
+		return result;
 	}
 
 	public void assertValid(String IE) {
-	    baseValidator.assertValid(getInvalidValues(IE));
+		baseValidator.assertValid(getInvalidValues(IE));
 	}
 
 	public List<ValidationMessage> invalidMessagesFor(String IE) {
-	    return baseValidator.generateValidationMessages(getInvalidValues(IE));
+		return baseValidator.generateValidationMessages(getInvalidValues(IE));
 	}
 
 	protected abstract boolean hasValidCheckDigits(String value);
 
+	protected String format(String value, String pattern, String validCharacters) {
+		try {
+			final MaskFormatter formatador = new MaskFormatter(pattern);
+			formatador.setValidCharacters(validCharacters);
+			formatador.setValueContainsLiteralCharacters(false);
+			return formatador.valueToString(value);
+		} catch (ParseException e) {
+			throw new RuntimeException("Valor gerado não bate com o padrão: " + value, e);
+		}
+	}
+
+	protected String format(String value, String pattern) {
+		return this.format(value, pattern, "1234567890");
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/AbstractIEValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/AbstractIEValidator.java
@@ -16,88 +16,88 @@ import br.com.caelum.stella.validation.error.IEError;
 
 public abstract class AbstractIEValidator implements Validator<String> {
 
-    protected final boolean isFormatted;
-    private final BaseValidator baseValidator;
+	protected final boolean isFormatted;
+	private final BaseValidator baseValidator;
 
-    public AbstractIEValidator() {
-        this(true);
-    }
+	public AbstractIEValidator() {
+		this(true);
+	}
 
-    public AbstractIEValidator(boolean isFormatted) {
-        this.isFormatted = isFormatted;
-        this.baseValidator = new BaseValidator();
-    }
+	public AbstractIEValidator(boolean isFormatted) {
+		this.isFormatted = isFormatted;
+		this.baseValidator = new BaseValidator();
+	}
 
-    public AbstractIEValidator(MessageProducer messageProducer, boolean isFormatted) {
-        this.baseValidator = new BaseValidator(messageProducer);
-        this.isFormatted = isFormatted;
-    }
+	public AbstractIEValidator(MessageProducer messageProducer, boolean isFormatted) {
+		this.baseValidator = new BaseValidator(messageProducer);
+		this.isFormatted = isFormatted;
+	}
 
-    private List<InvalidValue> getInvalidValues(String IE) {
-        List<InvalidValue> errors = new ArrayList<InvalidValue>();
-        if (IE != null) {
-            String unformattedIE = checkForCorrectFormat(IE, errors);
-            if (errors.isEmpty()) {
-                if (!hasValidCheckDigits(unformattedIE)) {
-                    errors.add(IEError.INVALID_CHECK_DIGITS);
-                }
-            }
-        }
-        return errors;
-    }
+	private List<InvalidValue> getInvalidValues(String IE) {
+		List<InvalidValue> errors = new ArrayList<InvalidValue>();
+		if (IE != null) {
+			String unformattedIE = checkForCorrectFormat(IE, errors);
+			if (errors.isEmpty()) {
+				if (!hasValidCheckDigits(unformattedIE)) {
+					errors.add(IEError.INVALID_CHECK_DIGITS);
+				}
+			}
+		}
+		return errors;
+	}
 
-    protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
-        String unformatedIE = null;
-        if (isFormatted) {
-            if (!(getFormattedPattern().matcher(ie).matches())) {
-                errors.add(IEError.INVALID_FORMAT);
-            }
-            unformatedIE = ie.replaceAll("\\D", "");
-        } else {
-            if (!getUnformattedPattern().matcher(ie).matches()) {
-                errors.add(IEError.INVALID_DIGITS);
-            }
-            unformatedIE = ie;
-        }
-        return unformatedIE;
-    }
+	protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
+		String unformatedIE = null;
+		if (isFormatted) {
+			if (!(getFormattedPattern().matcher(ie).matches())) {
+				errors.add(IEError.INVALID_FORMAT);
+			}
+			unformatedIE = ie.replaceAll("\\D", "");
+		} else {
+			if (!getUnformattedPattern().matcher(ie).matches()) {
+				errors.add(IEError.INVALID_DIGITS);
+			}
+			unformatedIE = ie;
+		}
+		return unformatedIE;
+	}
 
-    protected abstract Pattern getUnformattedPattern();
+	protected abstract Pattern getUnformattedPattern();
 
-    protected abstract Pattern getFormattedPattern();
+	protected abstract Pattern getFormattedPattern();
 
-    public boolean isEligible(String value) {
-        boolean result;
-        if (isFormatted) {
-            result = getFormattedPattern().matcher(value).matches();
-        } else {
-            result = getUnformattedPattern().matcher(value).matches();
-        }
-        return result;
-    }
+	public boolean isEligible(String value) {
+		boolean result;
+		if (isFormatted) {
+			result = getFormattedPattern().matcher(value).matches();
+		} else {
+			result = getUnformattedPattern().matcher(value).matches();
+		}
+		return result;
+	}
 
-    public void assertValid(String IE) {
-        baseValidator.assertValid(getInvalidValues(IE));
-    }
+	public void assertValid(String IE) {
+		baseValidator.assertValid(getInvalidValues(IE));
+	}
 
-    public List<ValidationMessage> invalidMessagesFor(String IE) {
-        return baseValidator.generateValidationMessages(getInvalidValues(IE));
-    }
+	public List<ValidationMessage> invalidMessagesFor(String IE) {
+		return baseValidator.generateValidationMessages(getInvalidValues(IE));
+	}
 
-    protected abstract boolean hasValidCheckDigits(String value);
+	protected abstract boolean hasValidCheckDigits(String value);
 
-    protected String format(String value, String pattern, String validCharacters) {
-        try {
-            final MaskFormatter formatador = new MaskFormatter(pattern);
-            formatador.setValidCharacters(validCharacters);
-            formatador.setValueContainsLiteralCharacters(false);
-            return formatador.valueToString(value);
-        } catch (ParseException e) {
-            throw new RuntimeException("Valor gerado não bate com o padrão: " + value, e);
-        }
-    }
+	protected String format(String value, String pattern, String validCharacters) {
+		try {
+			final MaskFormatter formatador = new MaskFormatter(pattern);
+			formatador.setValidCharacters(validCharacters);
+			formatador.setValueContainsLiteralCharacters(false);
+			return formatador.valueToString(value);
+		} catch (ParseException e) {
+			throw new RuntimeException("Valor gerado não bate com o padrão: " + value, e);
+		}
+	}
 
-    protected String format(String value, String pattern) {
-        return this.format(value, pattern, "1234567890");
-    }
+	protected String format(String value, String pattern) {
+		return this.format(value, pattern, "1234567890");
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/AbstractIEValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/AbstractIEValidator.java
@@ -16,88 +16,88 @@ import br.com.caelum.stella.validation.error.IEError;
 
 public abstract class AbstractIEValidator implements Validator<String> {
 
-	protected final boolean isFormatted;
-	private final BaseValidator baseValidator;
+    protected final boolean isFormatted;
+    private final BaseValidator baseValidator;
 
-	public AbstractIEValidator() {
-		this(true);
-	}
+    public AbstractIEValidator() {
+        this(true);
+    }
 
-	public AbstractIEValidator(boolean isFormatted) {
-		this.isFormatted = isFormatted;
-		this.baseValidator = new BaseValidator();
-	}
+    public AbstractIEValidator(boolean isFormatted) {
+        this.isFormatted = isFormatted;
+        this.baseValidator = new BaseValidator();
+    }
 
-	public AbstractIEValidator(MessageProducer messageProducer, boolean isFormatted) {
-		this.baseValidator = new BaseValidator(messageProducer);
-		this.isFormatted = isFormatted;
-	}
+    public AbstractIEValidator(MessageProducer messageProducer, boolean isFormatted) {
+        this.baseValidator = new BaseValidator(messageProducer);
+        this.isFormatted = isFormatted;
+    }
 
-	private List<InvalidValue> getInvalidValues(String IE) {
-		List<InvalidValue> errors = new ArrayList<InvalidValue>();
-		if (IE != null) {
-			String unformattedIE = checkForCorrectFormat(IE, errors);
-			if (errors.isEmpty()) {
-				if (!hasValidCheckDigits(unformattedIE)) {
-					errors.add(IEError.INVALID_CHECK_DIGITS);
-				}
-			}
-		}
-		return errors;
-	}
+    private List<InvalidValue> getInvalidValues(String IE) {
+        List<InvalidValue> errors = new ArrayList<InvalidValue>();
+        if (IE != null) {
+            String unformattedIE = checkForCorrectFormat(IE, errors);
+            if (errors.isEmpty()) {
+                if (!hasValidCheckDigits(unformattedIE)) {
+                    errors.add(IEError.INVALID_CHECK_DIGITS);
+                }
+            }
+        }
+        return errors;
+    }
 
-	protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
-		String unformatedIE = null;
-		if (isFormatted) {
-			if (!(getFormattedPattern().matcher(ie).matches())) {
-				errors.add(IEError.INVALID_FORMAT);
-			}
-			unformatedIE = ie.replaceAll("\\D", "");
-		} else {
-			if (!getUnformattedPattern().matcher(ie).matches()) {
-				errors.add(IEError.INVALID_DIGITS);
-			}
-			unformatedIE = ie;
-		}
-		return unformatedIE;
-	}
+    protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
+        String unformatedIE = null;
+        if (isFormatted) {
+            if (!(getFormattedPattern().matcher(ie).matches())) {
+                errors.add(IEError.INVALID_FORMAT);
+            }
+            unformatedIE = ie.replaceAll("\\D", "");
+        } else {
+            if (!getUnformattedPattern().matcher(ie).matches()) {
+                errors.add(IEError.INVALID_DIGITS);
+            }
+            unformatedIE = ie;
+        }
+        return unformatedIE;
+    }
 
-	protected abstract Pattern getUnformattedPattern();
+    protected abstract Pattern getUnformattedPattern();
 
-	protected abstract Pattern getFormattedPattern();
+    protected abstract Pattern getFormattedPattern();
 
-	public boolean isEligible(String value) {
-		boolean result;
-		if (isFormatted) {
-			result = getFormattedPattern().matcher(value).matches();
-		} else {
-			result = getUnformattedPattern().matcher(value).matches();
-		}
-		return result;
-	}
+    public boolean isEligible(String value) {
+        boolean result;
+        if (isFormatted) {
+            result = getFormattedPattern().matcher(value).matches();
+        } else {
+            result = getUnformattedPattern().matcher(value).matches();
+        }
+        return result;
+    }
 
-	public void assertValid(String IE) {
-		baseValidator.assertValid(getInvalidValues(IE));
-	}
+    public void assertValid(String IE) {
+        baseValidator.assertValid(getInvalidValues(IE));
+    }
 
-	public List<ValidationMessage> invalidMessagesFor(String IE) {
-		return baseValidator.generateValidationMessages(getInvalidValues(IE));
-	}
+    public List<ValidationMessage> invalidMessagesFor(String IE) {
+        return baseValidator.generateValidationMessages(getInvalidValues(IE));
+    }
 
-	protected abstract boolean hasValidCheckDigits(String value);
+    protected abstract boolean hasValidCheckDigits(String value);
 
-	protected String format(String value, String pattern, String validCharacters) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter(pattern);
-			formatador.setValidCharacters(validCharacters);
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(value);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + value, e);
-		}
-	}
+    protected String format(String value, String pattern, String validCharacters) {
+        try {
+            final MaskFormatter formatador = new MaskFormatter(pattern);
+            formatador.setValidCharacters(validCharacters);
+            formatador.setValueContainsLiteralCharacters(false);
+            return formatador.valueToString(value);
+        } catch (ParseException e) {
+            throw new RuntimeException("Valor gerado não bate com o padrão: " + value, e);
+        }
+    }
 
-	protected String format(String value, String pattern) {
-		return this.format(value, pattern, "1234567890");
-	}
+    protected String format(String value, String pattern) {
+        return this.format(value, pattern, "1234567890");
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAcreValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAcreValidator.java
@@ -12,79 +12,79 @@ import br.com.caelum.stella.SimpleMessageProducer;
  * Documentação de referência:
  * </p>
  * <ul>
- * <li><a href="http://www.sefaz.al.gov.br/sintegra/cad_AC.asp">ROTEIRO DE CRÍTICA DA INSCRIÇÃO
- * ESTADUAL</a>
- * <li><a href="http://www.sintegra.gov.br/Cad_Estados/cad_AC.html">SINTEGRA - ROTEIRO DE
+ * <li><a href="http://www.sefaz.al.gov.br/sintegra/cad_AC.asp">ROTEIRO DE
  * CRÍTICA DA INSCRIÇÃO ESTADUAL</a>
+ * <li><a href="http://www.sintegra.gov.br/Cad_Estados/cad_AC.html">SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL</a>
  * </ul>
  * 
  */
 public class IEAcreValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("01(\\.\\d{3}){2}\\/\\d{3}\\-\\d{2}");
+    public static final Pattern FORMATED = Pattern.compile("01(\\.\\d{3}){2}\\/\\d{3}\\-\\d{2}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("01\\d{11}");
+    public static final Pattern UNFORMATED = Pattern.compile("01\\d{11}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEAcreValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEAcreValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEAcreValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEAcreValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEAcreValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEAcreValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	@Override
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
-		String digitosCalculados = calculaDigitos(iESemDigito);
+    @Override
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+        String digitosCalculados = calculaDigitos(iESemDigito);
 
-		return digitos.equals(digitosCalculados);
-	}
+        return digitos.equals(digitosCalculados);
+    }
 
-	private String calculaDigitos(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigitos(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		String digito1 = digitoPara.calcula();
-		digitoPara.addDigito(digito1);
-		String digito2 = digitoPara.calcula();
+        String digito1 = digitoPara.calcula();
+        digitoPara.addDigito(digito1);
+        String digito2 = digitoPara.calcula();
 
-		return digito1 + digito2;
-	}
+        return digito1 + digito2;
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigitos = "01" + new DigitoGenerator().generate(9);
-		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
-		if (isFormatted) {
-			return super.format(ieComDigitos, "##.###.###/###-##");
-		}
-		return ieComDigitos;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigitos = "01" + new DigitoGenerator().generate(9);
+        final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
+        if (isFormatted) {
+            return super.format(ieComDigitos, "##.###.###/###-##");
+        }
+        return ieComDigitos;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAcreValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAcreValidator.java
@@ -1,15 +1,11 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
 import br.com.caelum.stella.MessageProducer;
 import br.com.caelum.stella.SimpleMessageProducer;
-import br.com.caelum.stella.format.CNPJFormatter;
 
 /**
  * <p>
@@ -82,23 +78,12 @@ public class IEAcreValidator extends AbstractIEValidator {
 		return digito1 + digito2;
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###/###-##");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigitos = "01" + new DigitoGenerator().generate(9);
 		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
 		if (isFormatted) {
-			return formata(ieComDigitos);
+			return super.format(ieComDigitos, "##.###.###/###-##");
 		}
 		return ieComDigitos;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAcreValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAcreValidator.java
@@ -21,70 +21,70 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEAcreValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("01(\\.\\d{3}){2}\\/\\d{3}\\-\\d{2}");
+	public static final Pattern FORMATED = Pattern.compile("01(\\.\\d{3}){2}\\/\\d{3}\\-\\d{2}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("01\\d{11}");
+	public static final Pattern UNFORMATED = Pattern.compile("01\\d{11}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEAcreValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEAcreValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEAcreValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEAcreValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEAcreValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEAcreValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    @Override
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
-        String digitosCalculados = calculaDigitos(iESemDigito);
+	@Override
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+		String digitosCalculados = calculaDigitos(iESemDigito);
 
-        return digitos.equals(digitosCalculados);
-    }
+		return digitos.equals(digitosCalculados);
+	}
 
-    private String calculaDigitos(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigitos(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        String digito1 = digitoPara.calcula();
-        digitoPara.addDigito(digito1);
-        String digito2 = digitoPara.calcula();
+		String digito1 = digitoPara.calcula();
+		digitoPara.addDigito(digito1);
+		String digito2 = digitoPara.calcula();
 
-        return digito1 + digito2;
-    }
+		return digito1 + digito2;
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigitos = "01" + new DigitoGenerator().generate(9);
-        final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
-        if (isFormatted) {
-            return super.format(ieComDigitos, "##.###.###/###-##");
-        }
-        return ieComDigitos;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigitos = "01" + new DigitoGenerator().generate(9);
+		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
+		if (isFormatted) {
+			return super.format(ieComDigitos, "##.###.###/###-##");
+		}
+		return ieComDigitos;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAlagoasValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAlagoasValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -15,16 +12,16 @@ import br.com.caelum.stella.SimpleMessageProducer;
  * Documentação de referência:
  * </p>
  * <a href="http://www.pfe.fazenda.sp.gov.br/consist_ie.shtm">Secretaria da
- * Fazenda do Estado de São Paulo</a> <a
- * href="http://www.sintegra.gov.br/Cad_Estados/cad_AL.html">SINTEGRA - ROTEIRO
- * DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * Fazenda do Estado de São Paulo</a>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_AL.html">SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  */
 public class IEAlagoasValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("24(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("24(\\.\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
 
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
@@ -49,7 +46,6 @@ public class IEAlagoasValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -59,15 +55,15 @@ public class IEAlagoasValidator extends AbstractIEValidator {
 	protected Pattern getFormattedPattern() {
 		return FORMATED;
 	}
-	
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -76,24 +72,12 @@ public class IEAlagoasValidator extends AbstractIEValidator {
 		return digitoPara.calcula();
 	}
 
-
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = "24" + new DigitoGenerator().generate(6);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAlagoasValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAlagoasValidator.java
@@ -19,66 +19,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEAlagoasValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("24(\\.\\d{3}){2}\\-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("24(\\.\\d{3}){2}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
+    public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEAlagoasValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEAlagoasValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEAlagoasValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEAlagoasValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEAlagoasValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEAlagoasValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = "24" + new DigitoGenerator().generate(6);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = "24" + new DigitoGenerator().generate(6);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.###.###-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAlagoasValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAlagoasValidator.java
@@ -19,66 +19,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEAlagoasValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("24(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("24(\\.\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEAlagoasValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEAlagoasValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEAlagoasValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEAlagoasValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEAlagoasValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEAlagoasValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = "24" + new DigitoGenerator().generate(6);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.###.###-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = "24" + new DigitoGenerator().generate(6);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmapaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmapaValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -15,16 +12,17 @@ import br.com.caelum.stella.SimpleMessageProducer;
  * Documentação de referência:
  * </p>
  * <a href="http://www.pfe.fazenda.sp.gov.br/consist_ie.shtm">Secretaria da
- * Fazenda do Estado de São Paulo</a> <a
- * href="http://www.sintegra.gov.br/Cad_Estados/cad_AP.html">SINTEGRA - ROTEIRO
- * DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * Fazenda do Estado de São Paulo</a>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_AP.html">SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  */
 public class IEAmapaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("(03)[.](\\d{3})\\.?(\\d{3})[-](\\d{1})");
+	public static final Pattern FORMATED = Pattern.compile("(03)[.](\\d{3})\\.?(\\d{3})[-](\\d{1})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(03)(\\d{3})(\\d{3})(\\d{1})");
+	public static final Pattern UNFORMATED = Pattern.compile("(03)(\\d{3})(\\d{3})(\\d{1})");
+
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
@@ -48,7 +46,6 @@ public class IEAmapaValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -58,8 +55,8 @@ public class IEAmapaValidator extends AbstractIEValidator {
 	protected Pattern getFormattedPattern() {
 		return FORMATED;
 	}
-	
-    @Override
+
+	@Override
 	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
@@ -70,38 +67,26 @@ public class IEAmapaValidator extends AbstractIEValidator {
 
 	private String calculaDigito(String iESemDigito) {
 		int ie = Integer.parseInt(iESemDigito);
-        /*
-         * http://www.sintegra.gov.br/Cad_Estados/cad_AP.html
-         * 
-         * De 03000001X a 03017000X => CASO 1 (p=5; d=0)
-         * 
-         * De 03017001X a 03019022X => CASO 2 (p=9; d=1)
-         * 
-         * De 03019023X em diante => CASO 3 (p=0; d=0)
-         */
-        String p = "0";
-        String d = "0";
-        if ((3000001 <= ie) && (ie <= 3017000)) {
-        	p = "5";
-        } else if ((3017001 <= ie) && (ie <= 3019022)) {
-        	p = "9";
-        	d = "1";
-        }
-        
-        return new DigitoPara(iESemDigito).addDigito(p).comMultiplicadoresDeAte(1, 9).complementarAoModulo()
-        			.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar(d, 11).calcula();
-    }
-
-
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
+		/*
+		 * http://www.sintegra.gov.br/Cad_Estados/cad_AP.html
+		 * 
+		 * De 03000001X a 03017000X => CASO 1 (p=5; d=0)
+		 * 
+		 * De 03017001X a 03019022X => CASO 2 (p=9; d=1)
+		 * 
+		 * De 03019023X em diante => CASO 3 (p=0; d=0)
+		 */
+		String p = "0";
+		String d = "0";
+		if ((3000001 <= ie) && (ie <= 3017000)) {
+			p = "5";
+		} else if ((3017001 <= ie) && (ie <= 3019022)) {
+			p = "9";
+			d = "1";
 		}
+
+		return new DigitoPara(iESemDigito).addDigito(p).comMultiplicadoresDeAte(1, 9).complementarAoModulo()
+				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar(d, 11).calcula();
 	}
 
 	@Override
@@ -109,7 +94,7 @@ public class IEAmapaValidator extends AbstractIEValidator {
 		final String ieSemDigito = "03" + new DigitoGenerator().generate(6);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmapaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmapaValidator.java
@@ -19,83 +19,83 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEAmapaValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("(03)[.](\\d{3})\\.?(\\d{3})[-](\\d{1})");
+    public static final Pattern FORMATED = Pattern.compile("(03)[.](\\d{3})\\.?(\\d{3})[-](\\d{1})");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(03)(\\d{3})(\\d{3})(\\d{1})");
+    public static final Pattern UNFORMATED = Pattern.compile("(03)(\\d{3})(\\d{3})(\\d{1})");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEAmapaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEAmapaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEAmapaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEAmapaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEAmapaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEAmapaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	@Override
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
-		String digitoCalculado = calculaDigito(iESemDigito);
+    @Override
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		int ie = Integer.parseInt(iESemDigito);
-		/*
-		 * http://www.sintegra.gov.br/Cad_Estados/cad_AP.html
-		 * 
-		 * De 03000001X a 03017000X => CASO 1 (p=5; d=0)
-		 * 
-		 * De 03017001X a 03019022X => CASO 2 (p=9; d=1)
-		 * 
-		 * De 03019023X em diante => CASO 3 (p=0; d=0)
-		 */
-		String p = "0";
-		String d = "0";
-		if ((3000001 <= ie) && (ie <= 3017000)) {
-			p = "5";
-		} else if ((3017001 <= ie) && (ie <= 3019022)) {
-			p = "9";
-			d = "1";
-		}
+    private String calculaDigito(String iESemDigito) {
+        int ie = Integer.parseInt(iESemDigito);
+        /*
+         * http://www.sintegra.gov.br/Cad_Estados/cad_AP.html
+         * 
+         * De 03000001X a 03017000X => CASO 1 (p=5; d=0)
+         * 
+         * De 03017001X a 03019022X => CASO 2 (p=9; d=1)
+         * 
+         * De 03019023X em diante => CASO 3 (p=0; d=0)
+         */
+        String p = "0";
+        String d = "0";
+        if ((3000001 <= ie) && (ie <= 3017000)) {
+            p = "5";
+        } else if ((3017001 <= ie) && (ie <= 3019022)) {
+            p = "9";
+            d = "1";
+        }
 
-		return new DigitoPara(iESemDigito).addDigito(p).comMultiplicadoresDeAte(1, 9).complementarAoModulo()
-				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar(d, 11).calcula();
-	}
+        return new DigitoPara(iESemDigito).addDigito(p).comMultiplicadoresDeAte(1, 9).complementarAoModulo()
+                .trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar(d, 11).calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = "03" + new DigitoGenerator().generate(6);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = "03" + new DigitoGenerator().generate(6);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.###.###-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmapaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmapaValidator.java
@@ -19,83 +19,83 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEAmapaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("(03)[.](\\d{3})\\.?(\\d{3})[-](\\d{1})");
+	public static final Pattern FORMATED = Pattern.compile("(03)[.](\\d{3})\\.?(\\d{3})[-](\\d{1})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(03)(\\d{3})(\\d{3})(\\d{1})");
+	public static final Pattern UNFORMATED = Pattern.compile("(03)(\\d{3})(\\d{3})(\\d{1})");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEAmapaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEAmapaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEAmapaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEAmapaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEAmapaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEAmapaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    @Override
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
-        String digitoCalculado = calculaDigito(iESemDigito);
+	@Override
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        int ie = Integer.parseInt(iESemDigito);
-        /*
-         * http://www.sintegra.gov.br/Cad_Estados/cad_AP.html
-         * 
-         * De 03000001X a 03017000X => CASO 1 (p=5; d=0)
-         * 
-         * De 03017001X a 03019022X => CASO 2 (p=9; d=1)
-         * 
-         * De 03019023X em diante => CASO 3 (p=0; d=0)
-         */
-        String p = "0";
-        String d = "0";
-        if ((3000001 <= ie) && (ie <= 3017000)) {
-            p = "5";
-        } else if ((3017001 <= ie) && (ie <= 3019022)) {
-            p = "9";
-            d = "1";
-        }
+	private String calculaDigito(String iESemDigito) {
+		int ie = Integer.parseInt(iESemDigito);
+		/*
+		 * http://www.sintegra.gov.br/Cad_Estados/cad_AP.html
+		 * 
+		 * De 03000001X a 03017000X => CASO 1 (p=5; d=0)
+		 * 
+		 * De 03017001X a 03019022X => CASO 2 (p=9; d=1)
+		 * 
+		 * De 03019023X em diante => CASO 3 (p=0; d=0)
+		 */
+		String p = "0";
+		String d = "0";
+		if ((3000001 <= ie) && (ie <= 3017000)) {
+			p = "5";
+		} else if ((3017001 <= ie) && (ie <= 3019022)) {
+			p = "9";
+			d = "1";
+		}
 
-        return new DigitoPara(iESemDigito).addDigito(p).comMultiplicadoresDeAte(1, 9).complementarAoModulo()
-                .trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar(d, 11).calcula();
-    }
+		return new DigitoPara(iESemDigito).addDigito(p).comMultiplicadoresDeAte(1, 9).complementarAoModulo()
+				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar(d, 11).calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = "03" + new DigitoGenerator().generate(6);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.###.###-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = "03" + new DigitoGenerator().generate(6);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmazonasValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmazonasValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -14,7 +11,7 @@ public class IEAmazonasValidator extends AbstractIEValidator {
 
 	public static final Pattern FORMATED = Pattern.compile("(\\d{2})[.](\\d{3})[.](\\d{3})[-](\\d{1})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(\\d{2})(\\d{3})(\\d{3})(\\d{1})");
+	public static final Pattern UNFORMATED = Pattern.compile("(\\d{2})(\\d{3})(\\d{3})(\\d{1})");
 
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
@@ -39,7 +36,6 @@ public class IEAmazonasValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -50,14 +46,14 @@ public class IEAmazonasValidator extends AbstractIEValidator {
 		return FORMATED;
 	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -66,24 +62,12 @@ public class IEAmazonasValidator extends AbstractIEValidator {
 		return digitoPara.calcula();
 	}
 
-
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = new DigitoGenerator().generate(8);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmazonasValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmazonasValidator.java
@@ -9,66 +9,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IEAmazonasValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("(\\d{2})[.](\\d{3})[.](\\d{3})[-](\\d{1})");
+    public static final Pattern FORMATED = Pattern.compile("(\\d{2})[.](\\d{3})[.](\\d{3})[-](\\d{1})");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(\\d{2})(\\d{3})(\\d{3})(\\d{1})");
+    public static final Pattern UNFORMATED = Pattern.compile("(\\d{2})(\\d{3})(\\d{3})(\\d{1})");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEAmazonasValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEAmazonasValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEAmazonasValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEAmazonasValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEAmazonasValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEAmazonasValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = new DigitoGenerator().generate(8);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = new DigitoGenerator().generate(8);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.###.###-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmazonasValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEAmazonasValidator.java
@@ -9,66 +9,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IEAmazonasValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("(\\d{2})[.](\\d{3})[.](\\d{3})[-](\\d{1})");
+	public static final Pattern FORMATED = Pattern.compile("(\\d{2})[.](\\d{3})[.](\\d{3})[-](\\d{1})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(\\d{2})(\\d{3})(\\d{3})(\\d{1})");
+	public static final Pattern UNFORMATED = Pattern.compile("(\\d{2})(\\d{3})(\\d{3})(\\d{1})");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEAmazonasValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEAmazonasValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEAmazonasValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEAmazonasValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEAmazonasValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEAmazonasValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = new DigitoGenerator().generate(8);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.###.###-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = new DigitoGenerator().generate(8);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEBahiaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEBahiaValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -16,9 +13,9 @@ import br.com.caelum.stella.validation.Validator;
  * Documentação de referência:
  * </p>
  * <a href="http://www.pfe.fazenda.sp.gov.br/consist_ie.shtm">Secretaria da
- * Fazenda do Estado de São Paulo</a> <a
- * href="http://www.sintegra.gov.br/Cad_Estados/cad_BA.html">SINTEGRA - ROTEIRO
- * DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * Fazenda do Estado de São Paulo</a>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_BA.html">SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  */
 public class IEBahiaValidator extends AbstractIEValidator {
@@ -102,17 +99,6 @@ public class IEBahiaValidator extends AbstractIEValidator {
 		return digito1 + digito2;
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("######-##");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	/**
 	 * Gera uma inscrição estadual com 8 dígitos
 	 * 
@@ -124,7 +110,7 @@ public class IEBahiaValidator extends AbstractIEValidator {
 		final String ieSemDigitos = new DigitoGenerator().generate(6);
 		final String ieComDigitos = ieSemDigitos + calculaDigito(ieSemDigitos);
 		if (isFormatted) {
-			return formata(ieComDigitos);
+			return super.format(ieComDigitos, "######-##");
 		}
 		return ieComDigitos;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEBahiaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEBahiaValidator.java
@@ -20,98 +20,98 @@ import br.com.caelum.stella.validation.Validator;
  */
 public class IEBahiaValidator extends AbstractIEValidator {
 
-	/*
-	 * 612345-57
-	 * 
-	 * 123456-63
-	 */
-	public static final Pattern FORMATED = Pattern.compile("(\\d{6,7}-\\d{2})|(\\d{2,3}\\.\\d{3}\\.\\d{3})");
+    /*
+     * 612345-57
+     * 
+     * 123456-63
+     */
+    public static final Pattern FORMATED = Pattern.compile("(\\d{6,7}-\\d{2})|(\\d{2,3}\\.\\d{3}\\.\\d{3})");
 
-	public static final Pattern UNFORMATED = Pattern.compile("\\d{8,9}");
+    public static final Pattern UNFORMATED = Pattern.compile("\\d{8,9}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEBahiaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEBahiaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEBahiaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEBahiaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEBahiaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEBahiaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
 
-		String digitosCalculados = calculaDigito(iESemDigito);
+        String digitosCalculados = calculaDigito(iESemDigito);
 
-		return digitos.equals(digitosCalculados);
-	}
+        return digitos.equals(digitosCalculados);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		char charToCheck;
-		if (iESemDigito.length() == 6) {
-			charToCheck = iESemDigito.charAt(0);
-		} else {
-			charToCheck = iESemDigito.charAt(1);
-		}
+        char charToCheck;
+        if (iESemDigito.length() == 6) {
+            charToCheck = iESemDigito.charAt(0);
+        } else {
+            charToCheck = iESemDigito.charAt(1);
+        }
 
-		switch (charToCheck) {
-		case '6':
-		case '7':
-		case '9':
-			digitoPara.mod(11);
-			break;
-		default:
-			digitoPara.mod(10);
-		}
+        switch (charToCheck) {
+        case '6':
+        case '7':
+        case '9':
+            digitoPara.mod(11);
+            break;
+        default:
+            digitoPara.mod(10);
+        }
 
-		String digito2 = digitoPara.calcula();
-		digitoPara.addDigito(digito2);
-		String digito1 = digitoPara.calcula();
+        String digito2 = digitoPara.calcula();
+        digitoPara.addDigito(digito2);
+        String digito1 = digitoPara.calcula();
 
-		return digito1 + digito2;
-	}
+        return digito1 + digito2;
+    }
 
-	/**
-	 * Gera uma inscrição estadual com 8 dígitos
-	 * 
-	 * @see Validator#generateRandomValid()
-	 * @return uma inscrição estadual aleatória válida
-	 */
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigitos = new DigitoGenerator().generate(6);
-		final String ieComDigitos = ieSemDigitos + calculaDigito(ieSemDigitos);
-		if (isFormatted) {
-			return super.format(ieComDigitos, "######-##");
-		}
-		return ieComDigitos;
-	}
+    /**
+     * Gera uma inscrição estadual com 8 dígitos
+     * 
+     * @see Validator#generateRandomValid()
+     * @return uma inscrição estadual aleatória válida
+     */
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigitos = new DigitoGenerator().generate(6);
+        final String ieComDigitos = ieSemDigitos + calculaDigito(ieSemDigitos);
+        if (isFormatted) {
+            return super.format(ieComDigitos, "######-##");
+        }
+        return ieComDigitos;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEBahiaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEBahiaValidator.java
@@ -20,98 +20,98 @@ import br.com.caelum.stella.validation.Validator;
  */
 public class IEBahiaValidator extends AbstractIEValidator {
 
-    /*
-     * 612345-57
-     * 
-     * 123456-63
-     */
-    public static final Pattern FORMATED = Pattern.compile("(\\d{6,7}-\\d{2})|(\\d{2,3}\\.\\d{3}\\.\\d{3})");
+	/*
+	 * 612345-57
+	 * 
+	 * 123456-63
+	 */
+	public static final Pattern FORMATED = Pattern.compile("(\\d{6,7}-\\d{2})|(\\d{2,3}\\.\\d{3}\\.\\d{3})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{8,9}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{8,9}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEBahiaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEBahiaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEBahiaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEBahiaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEBahiaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEBahiaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
 
-        String digitosCalculados = calculaDigito(iESemDigito);
+		String digitosCalculados = calculaDigito(iESemDigito);
 
-        return digitos.equals(digitosCalculados);
-    }
+		return digitos.equals(digitosCalculados);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        char charToCheck;
-        if (iESemDigito.length() == 6) {
-            charToCheck = iESemDigito.charAt(0);
-        } else {
-            charToCheck = iESemDigito.charAt(1);
-        }
+		char charToCheck;
+		if (iESemDigito.length() == 6) {
+			charToCheck = iESemDigito.charAt(0);
+		} else {
+			charToCheck = iESemDigito.charAt(1);
+		}
 
-        switch (charToCheck) {
-        case '6':
-        case '7':
-        case '9':
-            digitoPara.mod(11);
-            break;
-        default:
-            digitoPara.mod(10);
-        }
+		switch (charToCheck) {
+		case '6':
+		case '7':
+		case '9':
+			digitoPara.mod(11);
+			break;
+		default:
+			digitoPara.mod(10);
+		}
 
-        String digito2 = digitoPara.calcula();
-        digitoPara.addDigito(digito2);
-        String digito1 = digitoPara.calcula();
+		String digito2 = digitoPara.calcula();
+		digitoPara.addDigito(digito2);
+		String digito1 = digitoPara.calcula();
 
-        return digito1 + digito2;
-    }
+		return digito1 + digito2;
+	}
 
-    /**
-     * Gera uma inscrição estadual com 8 dígitos
-     * 
-     * @see Validator#generateRandomValid()
-     * @return uma inscrição estadual aleatória válida
-     */
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigitos = new DigitoGenerator().generate(6);
-        final String ieComDigitos = ieSemDigitos + calculaDigito(ieSemDigitos);
-        if (isFormatted) {
-            return super.format(ieComDigitos, "######-##");
-        }
-        return ieComDigitos;
-    }
+	/**
+	 * Gera uma inscrição estadual com 8 dígitos
+	 * 
+	 * @see Validator#generateRandomValid()
+	 * @return uma inscrição estadual aleatória válida
+	 */
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigitos = new DigitoGenerator().generate(6);
+		final String ieComDigitos = ieSemDigitos + calculaDigito(ieSemDigitos);
+		if (isFormatted) {
+			return super.format(ieComDigitos, "######-##");
+		}
+		return ieComDigitos;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IECearaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IECearaValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -15,23 +12,24 @@ import br.com.caelum.stella.SimpleMessageProducer;
  * Documentação de referência:
  * </p>
  * <a href="http://www.pfe.fazenda.sp.gov.br/consist_ie.shtm">Secretaria da
- * Fazenda do Estado de São Paulo</a> <a
- * href="http://www.sintegra.gov.br/Cad_Estados/cad_CE.html">SINTEGRA - ROTEIRO
- * DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * Fazenda do Estado de São Paulo</a>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_CE.html">SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  * 
  */
 public class IECearaValidator extends AbstractIEValidator {
-  
-    /*
-     * Formato: 8 dígitos+1 dígito verificador
-     * 
-     * Exemplo: CGF número 06000001-5 Exemplo Formatado: 06.998.161-2
-     */
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{2}\\.\\d{3}\\.?\\d{3}-\\d{1}");
+	/*
+	 * Formato: 8 dígitos+1 dígito verificador
+	 * 
+	 * Exemplo: CGF número 06000001-5 Exemplo Formatado: 06.998.161-2
+	 */
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}\\.\\d{3}\\.?\\d{3}-\\d{1}");
+
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
@@ -55,7 +53,6 @@ public class IECearaValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -65,9 +62,8 @@ public class IECearaValidator extends AbstractIEValidator {
 	protected Pattern getFormattedPattern() {
 		return FORMATED;
 	}
-	
 
-    @Override
+	@Override
 	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
@@ -80,23 +76,12 @@ public class IECearaValidator extends AbstractIEValidator {
 		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11).calcula();
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = new DigitoGenerator().generate(8);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IECearaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IECearaValidator.java
@@ -20,69 +20,69 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IECearaValidator extends AbstractIEValidator {
 
-	/*
-	 * Formato: 8 dígitos+1 dígito verificador
-	 * 
-	 * Exemplo: CGF número 06000001-5 Exemplo Formatado: 06.998.161-2
-	 */
+    /*
+     * Formato: 8 dígitos+1 dígito verificador
+     * 
+     * Exemplo: CGF número 06000001-5 Exemplo Formatado: 06.998.161-2
+     */
 
-	public static final Pattern FORMATED = Pattern.compile("\\d{2}\\.\\d{3}\\.?\\d{3}-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("\\d{2}\\.\\d{3}\\.?\\d{3}-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IECearaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IECearaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IECearaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IECearaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IECearaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IECearaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	@Override
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
-		String digitoCalculado = calculaDigito(iESemDigito);
+    @Override
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11).calcula();
-	}
+    private String calculaDigito(String iESemDigito) {
+        return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11).calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = new DigitoGenerator().generate(8);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = new DigitoGenerator().generate(8);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.###.###-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IECearaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IECearaValidator.java
@@ -20,69 +20,69 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IECearaValidator extends AbstractIEValidator {
 
-    /*
-     * Formato: 8 dígitos+1 dígito verificador
-     * 
-     * Exemplo: CGF número 06000001-5 Exemplo Formatado: 06.998.161-2
-     */
+	/*
+	 * Formato: 8 dígitos+1 dígito verificador
+	 * 
+	 * Exemplo: CGF número 06000001-5 Exemplo Formatado: 06.998.161-2
+	 */
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{2}\\.\\d{3}\\.?\\d{3}-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}\\.\\d{3}\\.?\\d{3}-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IECearaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IECearaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IECearaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IECearaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IECearaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IECearaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    @Override
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
-        String digitoCalculado = calculaDigito(iESemDigito);
+	@Override
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11).calcula();
-    }
+	private String calculaDigito(String iESemDigito) {
+		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11).calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = new DigitoGenerator().generate(8);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.###.###-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = new DigitoGenerator().generate(8);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidator.java
@@ -1,10 +1,7 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.Random;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -16,20 +13,20 @@ import br.com.caelum.stella.SimpleMessageProducer;
  * Documentação de referência:
  * </p>
  * <a href="http://www.pfe.fazenda.sp.gov.br/consist_ie.shtm">Secretaria da
- * Fazenda do Estado de São Paulo</a> <a
- * href="http://www.sintegra.gov.br/Cad_Estados/cad_DF.html">SINTEGRA - ROTEIRO
- * DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * Fazenda do Estado de São Paulo</a>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_DF.html">SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  */
 public class IEDistritoFederalValidator extends AbstractIEValidator {
 
 	/*
-     * Formato: 07.408.738/002-50
-     */
+	 * Formato: 07.408.738/002-50
+	 */
 
-    public static final Pattern FORMATED = Pattern.compile("(07)[.]([3-9]\\d{2})[.](\\d{3})[/](\\d{3})[-](\\d{2})");
+	public static final Pattern FORMATED = Pattern.compile("(07)[.]([3-9]\\d{2})[.](\\d{3})[/](\\d{3})[-](\\d{2})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(07)([3-9]\\d{2})(\\d{3})(\\d{3})(\\d{2})");
+	public static final Pattern UNFORMATED = Pattern.compile("(07)([3-9]\\d{2})(\\d{3})(\\d{3})(\\d{2})");
 
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
@@ -54,7 +51,6 @@ public class IEDistritoFederalValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -64,8 +60,8 @@ public class IEDistritoFederalValidator extends AbstractIEValidator {
 	protected Pattern getFormattedPattern() {
 		return FORMATED;
 	}
-	
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
 		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
 		String digitosCalculados = calculaDigitos(iESemDigito);
@@ -84,17 +80,6 @@ public class IEDistritoFederalValidator extends AbstractIEValidator {
 		return digito1 + digito2;
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###/###-##");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-	
 	private String geraDoisPrimeirosDigitos() {
 		final Random random = new Random();
 		final String primeiroDigito = String.valueOf(random.nextInt(7) + 3);
@@ -107,7 +92,7 @@ public class IEDistritoFederalValidator extends AbstractIEValidator {
 		final String ieSemDigitos = "07" + geraDoisPrimeirosDigitos() + new DigitoGenerator().generate(7);
 		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
 		if (isFormatted) {
-			return formata(ieComDigitos);
+			return super.format(ieComDigitos, "##.###.###/###-##");
 		}
 		return ieComDigitos;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidator.java
@@ -20,80 +20,80 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEDistritoFederalValidator extends AbstractIEValidator {
 
-	/*
-	 * Formato: 07.408.738/002-50
-	 */
+    /*
+     * Formato: 07.408.738/002-50
+     */
 
-	public static final Pattern FORMATED = Pattern.compile("(07)[.]([3-9]\\d{2})[.](\\d{3})[/](\\d{3})[-](\\d{2})");
+    public static final Pattern FORMATED = Pattern.compile("(07)[.]([3-9]\\d{2})[.](\\d{3})[/](\\d{3})[-](\\d{2})");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(07)([3-9]\\d{2})(\\d{3})(\\d{3})(\\d{2})");
+    public static final Pattern UNFORMATED = Pattern.compile("(07)([3-9]\\d{2})(\\d{3})(\\d{3})(\\d{2})");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEDistritoFederalValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEDistritoFederalValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEDistritoFederalValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEDistritoFederalValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEDistritoFederalValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEDistritoFederalValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
-		String digitosCalculados = calculaDigitos(iESemDigito);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+        String digitosCalculados = calculaDigitos(iESemDigito);
 
-		return digitos.equals(digitosCalculados);
-	}
+        return digitos.equals(digitosCalculados);
+    }
 
-	private String calculaDigitos(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigitos(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		String digito1 = digitoPara.calcula();
-		digitoPara.addDigito(digito1);
-		String digito2 = digitoPara.calcula();
+        String digito1 = digitoPara.calcula();
+        digitoPara.addDigito(digito1);
+        String digito2 = digitoPara.calcula();
 
-		return digito1 + digito2;
-	}
+        return digito1 + digito2;
+    }
 
-	private String geraDoisPrimeirosDigitos() {
-		final Random random = new Random();
-		final String primeiroDigito = String.valueOf(random.nextInt(7) + 3);
-		final String segundoDigito = String.valueOf(random.nextInt(7) + 3);
-		return primeiroDigito + segundoDigito;
-	}
+    private String geraDoisPrimeirosDigitos() {
+        final Random random = new Random();
+        final String primeiroDigito = String.valueOf(random.nextInt(7) + 3);
+        final String segundoDigito = String.valueOf(random.nextInt(7) + 3);
+        return primeiroDigito + segundoDigito;
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigitos = "07" + geraDoisPrimeirosDigitos() + new DigitoGenerator().generate(7);
-		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
-		if (isFormatted) {
-			return super.format(ieComDigitos, "##.###.###/###-##");
-		}
-		return ieComDigitos;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigitos = "07" + geraDoisPrimeirosDigitos() + new DigitoGenerator().generate(7);
+        final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
+        if (isFormatted) {
+            return super.format(ieComDigitos, "##.###.###/###-##");
+        }
+        return ieComDigitos;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidator.java
@@ -20,80 +20,80 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEDistritoFederalValidator extends AbstractIEValidator {
 
-    /*
-     * Formato: 07.408.738/002-50
-     */
+	/*
+	 * Formato: 07.408.738/002-50
+	 */
 
-    public static final Pattern FORMATED = Pattern.compile("(07)[.]([3-9]\\d{2})[.](\\d{3})[/](\\d{3})[-](\\d{2})");
+	public static final Pattern FORMATED = Pattern.compile("(07)[.]([3-9]\\d{2})[.](\\d{3})[/](\\d{3})[-](\\d{2})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(07)([3-9]\\d{2})(\\d{3})(\\d{3})(\\d{2})");
+	public static final Pattern UNFORMATED = Pattern.compile("(07)([3-9]\\d{2})(\\d{3})(\\d{3})(\\d{2})");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEDistritoFederalValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEDistritoFederalValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEDistritoFederalValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEDistritoFederalValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEDistritoFederalValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEDistritoFederalValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
-        String digitosCalculados = calculaDigitos(iESemDigito);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+		String digitosCalculados = calculaDigitos(iESemDigito);
 
-        return digitos.equals(digitosCalculados);
-    }
+		return digitos.equals(digitosCalculados);
+	}
 
-    private String calculaDigitos(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigitos(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        String digito1 = digitoPara.calcula();
-        digitoPara.addDigito(digito1);
-        String digito2 = digitoPara.calcula();
+		String digito1 = digitoPara.calcula();
+		digitoPara.addDigito(digito1);
+		String digito2 = digitoPara.calcula();
 
-        return digito1 + digito2;
-    }
+		return digito1 + digito2;
+	}
 
-    private String geraDoisPrimeirosDigitos() {
-        final Random random = new Random();
-        final String primeiroDigito = String.valueOf(random.nextInt(7) + 3);
-        final String segundoDigito = String.valueOf(random.nextInt(7) + 3);
-        return primeiroDigito + segundoDigito;
-    }
+	private String geraDoisPrimeirosDigitos() {
+		final Random random = new Random();
+		final String primeiroDigito = String.valueOf(random.nextInt(7) + 3);
+		final String segundoDigito = String.valueOf(random.nextInt(7) + 3);
+		return primeiroDigito + segundoDigito;
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigitos = "07" + geraDoisPrimeirosDigitos() + new DigitoGenerator().generate(7);
-        final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
-        if (isFormatted) {
-            return super.format(ieComDigitos, "##.###.###/###-##");
-        }
-        return ieComDigitos;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigitos = "07" + geraDoisPrimeirosDigitos() + new DigitoGenerator().generate(7);
+		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
+		if (isFormatted) {
+			return super.format(ieComDigitos, "##.###.###/###-##");
+		}
+		return ieComDigitos;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEEspiritoSantoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEEspiritoSantoValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -11,16 +8,18 @@ import br.com.caelum.stella.MessageProducer;
 import br.com.caelum.stella.SimpleMessageProducer;
 
 /**
- * <p> Documentação de referência: </p>
- * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_ES.html">
- * SINTEGRA - ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * <p>
+ * Documentação de referência:
+ * </p>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_ES.html"> SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  */
 public class IEEspiritoSantoValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){2}\\d{2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){2}\\d{2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
@@ -45,7 +44,6 @@ public class IEEspiritoSantoValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -56,14 +54,14 @@ public class IEEspiritoSantoValidator extends AbstractIEValidator {
 		return FORMATED;
 	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -72,23 +70,12 @@ public class IEEspiritoSantoValidator extends AbstractIEValidator {
 		return digitoPara.calcula();
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("###.###.##-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = new DigitoGenerator().generate(8);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "###.###.##-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEEspiritoSantoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEEspiritoSantoValidator.java
@@ -17,66 +17,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEEspiritoSantoValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){2}\\d{2}\\-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){2}\\d{2}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEEspiritoSantoValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEEspiritoSantoValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEEspiritoSantoValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEEspiritoSantoValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEEspiritoSantoValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEEspiritoSantoValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = new DigitoGenerator().generate(8);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "###.###.##-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = new DigitoGenerator().generate(8);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "###.###.##-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEEspiritoSantoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEEspiritoSantoValidator.java
@@ -17,66 +17,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEEspiritoSantoValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){2}\\d{2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){2}\\d{2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEEspiritoSantoValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEEspiritoSantoValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEEspiritoSantoValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEEspiritoSantoValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEEspiritoSantoValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEEspiritoSantoValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = new DigitoGenerator().generate(8);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "###.###.##-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = new DigitoGenerator().generate(8);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "###.###.##-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEGoiasValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEGoiasValidator.java
@@ -1,10 +1,7 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.Random;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -16,18 +13,18 @@ import br.com.caelum.stella.SimpleMessageProducer;
  * Documentação de referência:
  * </p>
  * <a href="http://www.pfe.fazenda.sp.gov.br/consist_ie.shtm">Secretaria da
- * Fazenda do Estado de São Paulo</a> <a
- * href="http://www.sintegra.gov.br/Cad_Estados/cad_GO.html">SINTEGRA - ROTEIRO
- * DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * Fazenda do Estado de São Paulo</a>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_GO.html">SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  * @author Leonardo Bessa
  * 
  */
 public class IEGoiasValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("(1[015])[.](\\d{3})[.](\\d{3})[-](\\d{1})");
+	public static final Pattern FORMATED = Pattern.compile("(1[015])[.](\\d{3})[.](\\d{3})[-](\\d{1})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(1[015])(\\d{3})(\\d{3})(\\d{1})");
+	public static final Pattern UNFORMATED = Pattern.compile("(1[015])(\\d{3})(\\d{3})(\\d{1})");
 
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
@@ -52,7 +49,6 @@ public class IEGoiasValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -63,8 +59,7 @@ public class IEGoiasValidator extends AbstractIEValidator {
 		return FORMATED;
 	}
 
-
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 		String digitoCalculado = calculaDigito(iESemDigito);
@@ -73,7 +68,7 @@ public class IEGoiasValidator extends AbstractIEValidator {
 	}
 
 	private boolean regraBizarraDeGoias(String iESemDigito, String digito) {
-		if (iESemDigito.equals("11094402")){
+		if (iESemDigito.equals("11094402")) {
 			if (digito.equals("0") || digito.equals("1")) {
 				return true;
 			}
@@ -83,28 +78,18 @@ public class IEGoiasValidator extends AbstractIEValidator {
 
 	private String calculaDigito(String iESemDigito) {
 		int ie = Integer.parseInt(iESemDigito);
-        /*
-         * http://www.sintegra.gov.br/Cad_Estados/cad_GO.html
-         * 
-         * De 10103105X a 10119997X => d=1
-         */
-        String d = "0";
-        if ((10103105 <= ie) && (ie <= 10119997)) {
-        	d = "1";
-        }
-        
-        return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar(d, 10).trocandoPorSeEncontrar("0", 11).calcula();
-    }
-
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
+		/*
+		 * http://www.sintegra.gov.br/Cad_Estados/cad_GO.html
+		 * 
+		 * De 10103105X a 10119997X => d=1
+		 */
+		String d = "0";
+		if ((10103105 <= ie) && (ie <= 10119997)) {
+			d = "1";
 		}
+
+		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar(d, 10)
+				.trocandoPorSeEncontrar("0", 11).calcula();
 	}
 
 	@Override
@@ -115,7 +100,7 @@ public class IEGoiasValidator extends AbstractIEValidator {
 				+ new DigitoGenerator().generate(6);
 		final String ieComDigitos = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigitos);
+			return super.format(ieComDigitos, "##.###.###-#");
 		}
 		return ieComDigitos;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEGoiasValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEGoiasValidator.java
@@ -22,86 +22,86 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEGoiasValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("(1[015])[.](\\d{3})[.](\\d{3})[-](\\d{1})");
+    public static final Pattern FORMATED = Pattern.compile("(1[015])[.](\\d{3})[.](\\d{3})[-](\\d{1})");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(1[015])(\\d{3})(\\d{3})(\\d{1})");
+    public static final Pattern UNFORMATED = Pattern.compile("(1[015])(\\d{3})(\\d{3})(\\d{1})");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEGoiasValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEGoiasValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEGoiasValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEGoiasValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEGoiasValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEGoiasValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
-		String digitoCalculado = calculaDigito(iESemDigito);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return regraBizarraDeGoias(iESemDigito, digito) || digito.equals(digitoCalculado);
-	}
+        return regraBizarraDeGoias(iESemDigito, digito) || digito.equals(digitoCalculado);
+    }
 
-	private boolean regraBizarraDeGoias(String iESemDigito, String digito) {
-		if (iESemDigito.equals("11094402")) {
-			if (digito.equals("0") || digito.equals("1")) {
-				return true;
-			}
-		}
-		return false;
-	}
+    private boolean regraBizarraDeGoias(String iESemDigito, String digito) {
+        if (iESemDigito.equals("11094402")) {
+            if (digito.equals("0") || digito.equals("1")) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		int ie = Integer.parseInt(iESemDigito);
-		/*
-		 * http://www.sintegra.gov.br/Cad_Estados/cad_GO.html
-		 * 
-		 * De 10103105X a 10119997X => d=1
-		 */
-		String d = "0";
-		if ((10103105 <= ie) && (ie <= 10119997)) {
-			d = "1";
-		}
+    private String calculaDigito(String iESemDigito) {
+        int ie = Integer.parseInt(iESemDigito);
+        /*
+         * http://www.sintegra.gov.br/Cad_Estados/cad_GO.html
+         * 
+         * De 10103105X a 10119997X => d=1
+         */
+        String d = "0";
+        if ((10103105 <= ie) && (ie <= 10119997)) {
+            d = "1";
+        }
 
-		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar(d, 10)
-				.trocandoPorSeEncontrar("0", 11).calcula();
-	}
+        return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar(d, 10)
+                .trocandoPorSeEncontrar("0", 11).calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final int[] segundoDigitosPossiveis = new int[] { 0, 1, 5 };
-		final int segundoDigitoSorteado = new Random().nextInt(segundoDigitosPossiveis.length);
-		final String ieSemDigito = "1" + segundoDigitosPossiveis[segundoDigitoSorteado]
-				+ new DigitoGenerator().generate(6);
-		final String ieComDigitos = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigitos, "##.###.###-#");
-		}
-		return ieComDigitos;
-	}
+    @Override
+    public String generateRandomValid() {
+        final int[] segundoDigitosPossiveis = new int[] { 0, 1, 5 };
+        final int segundoDigitoSorteado = new Random().nextInt(segundoDigitosPossiveis.length);
+        final String ieSemDigito = "1" + segundoDigitosPossiveis[segundoDigitoSorteado]
+                + new DigitoGenerator().generate(6);
+        final String ieComDigitos = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigitos, "##.###.###-#");
+        }
+        return ieComDigitos;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEGoiasValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEGoiasValidator.java
@@ -22,86 +22,86 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEGoiasValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("(1[015])[.](\\d{3})[.](\\d{3})[-](\\d{1})");
+	public static final Pattern FORMATED = Pattern.compile("(1[015])[.](\\d{3})[.](\\d{3})[-](\\d{1})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(1[015])(\\d{3})(\\d{3})(\\d{1})");
+	public static final Pattern UNFORMATED = Pattern.compile("(1[015])(\\d{3})(\\d{3})(\\d{1})");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEGoiasValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEGoiasValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEGoiasValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEGoiasValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEGoiasValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEGoiasValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
-        String digitoCalculado = calculaDigito(iESemDigito);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return regraBizarraDeGoias(iESemDigito, digito) || digito.equals(digitoCalculado);
-    }
+		return regraBizarraDeGoias(iESemDigito, digito) || digito.equals(digitoCalculado);
+	}
 
-    private boolean regraBizarraDeGoias(String iESemDigito, String digito) {
-        if (iESemDigito.equals("11094402")) {
-            if (digito.equals("0") || digito.equals("1")) {
-                return true;
-            }
-        }
-        return false;
-    }
+	private boolean regraBizarraDeGoias(String iESemDigito, String digito) {
+		if (iESemDigito.equals("11094402")) {
+			if (digito.equals("0") || digito.equals("1")) {
+				return true;
+			}
+		}
+		return false;
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        int ie = Integer.parseInt(iESemDigito);
-        /*
-         * http://www.sintegra.gov.br/Cad_Estados/cad_GO.html
-         * 
-         * De 10103105X a 10119997X => d=1
-         */
-        String d = "0";
-        if ((10103105 <= ie) && (ie <= 10119997)) {
-            d = "1";
-        }
+	private String calculaDigito(String iESemDigito) {
+		int ie = Integer.parseInt(iESemDigito);
+		/*
+		 * http://www.sintegra.gov.br/Cad_Estados/cad_GO.html
+		 * 
+		 * De 10103105X a 10119997X => d=1
+		 */
+		String d = "0";
+		if ((10103105 <= ie) && (ie <= 10119997)) {
+			d = "1";
+		}
 
-        return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar(d, 10)
-                .trocandoPorSeEncontrar("0", 11).calcula();
-    }
+		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar(d, 10)
+				.trocandoPorSeEncontrar("0", 11).calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final int[] segundoDigitosPossiveis = new int[] { 0, 1, 5 };
-        final int segundoDigitoSorteado = new Random().nextInt(segundoDigitosPossiveis.length);
-        final String ieSemDigito = "1" + segundoDigitosPossiveis[segundoDigitoSorteado]
-                + new DigitoGenerator().generate(6);
-        final String ieComDigitos = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigitos, "##.###.###-#");
-        }
-        return ieComDigitos;
-    }
+	@Override
+	public String generateRandomValid() {
+		final int[] segundoDigitosPossiveis = new int[] { 0, 1, 5 };
+		final int segundoDigitoSorteado = new Random().nextInt(segundoDigitosPossiveis.length);
+		final String ieSemDigito = "1" + segundoDigitosPossiveis[segundoDigitoSorteado]
+				+ new DigitoGenerator().generate(6);
+		final String ieComDigitos = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigitos, "##.###.###-#");
+		}
+		return ieComDigitos;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMaranhaoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMaranhaoValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -15,24 +12,24 @@ import br.com.caelum.stella.SimpleMessageProducer;
  * Documentação de referência:
  * </p>
  * <a href="http://www.pfe.fazenda.sp.gov.br/consist_ie.shtm">Secretaria da
- * Fazenda do Estado de São Paulo</a> <a
- * href="http://www.sintegra.gov.br/Cad_Estados/cad_MA.html">SINTEGRA - ROTEIRO
- * DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * Fazenda do Estado de São Paulo</a>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_MA.html">SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  * @author Leonardo Bessa
  * 
  */
 public class IEMaranhaoValidator extends AbstractIEValidator {
 
-    /*
-     * Formato: 8 dígitos (empresa)+1 dígito verificador Exemplo:
-     */
+	/*
+	 * Formato: 8 dígitos (empresa)+1 dígito verificador Exemplo:
+	 */
 
-    public static final Pattern FORMATED = Pattern.compile("12\\.\\d{3}\\.?\\d{3}-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("12\\.\\d{3}\\.?\\d{3}-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(12)\\d{7}");
-	
-    /**
+	public static final Pattern UNFORMATED = Pattern.compile("(12)\\d{7}");
+
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -55,7 +52,6 @@ public class IEMaranhaoValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -66,15 +62,15 @@ public class IEMaranhaoValidator extends AbstractIEValidator {
 		return FORMATED;
 	}
 
-    @Override
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	@Override
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -83,23 +79,12 @@ public class IEMaranhaoValidator extends AbstractIEValidator {
 		return digitoPara.calcula();
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = "12" + new DigitoGenerator().generate(6);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMaranhaoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMaranhaoValidator.java
@@ -21,71 +21,71 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEMaranhaoValidator extends AbstractIEValidator {
 
-    /*
-     * Formato: 8 dígitos (empresa)+1 dígito verificador Exemplo:
-     */
+	/*
+	 * Formato: 8 dígitos (empresa)+1 dígito verificador Exemplo:
+	 */
 
-    public static final Pattern FORMATED = Pattern.compile("12\\.\\d{3}\\.?\\d{3}-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("12\\.\\d{3}\\.?\\d{3}-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(12)\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("(12)\\d{7}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEMaranhaoValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEMaranhaoValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEMaranhaoValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEMaranhaoValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEMaranhaoValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEMaranhaoValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    @Override
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	@Override
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = "12" + new DigitoGenerator().generate(6);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.###.###-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = "12" + new DigitoGenerator().generate(6);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMaranhaoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMaranhaoValidator.java
@@ -21,71 +21,71 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEMaranhaoValidator extends AbstractIEValidator {
 
-	/*
-	 * Formato: 8 dígitos (empresa)+1 dígito verificador Exemplo:
-	 */
+    /*
+     * Formato: 8 dígitos (empresa)+1 dígito verificador Exemplo:
+     */
 
-	public static final Pattern FORMATED = Pattern.compile("12\\.\\d{3}\\.?\\d{3}-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("12\\.\\d{3}\\.?\\d{3}-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(12)\\d{7}");
+    public static final Pattern UNFORMATED = Pattern.compile("(12)\\d{7}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEMaranhaoValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEMaranhaoValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEMaranhaoValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEMaranhaoValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEMaranhaoValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEMaranhaoValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	@Override
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    @Override
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = "12" + new DigitoGenerator().generate(6);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = "12" + new DigitoGenerator().generate(6);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.###.###-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoDoSulValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoDoSulValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -11,20 +8,22 @@ import br.com.caelum.stella.MessageProducer;
 import br.com.caelum.stella.SimpleMessageProducer;
 
 /**
- * <p> Documentação de referência: </p>
- * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_MS.html">
- * SINTEGRA - ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * <p>
+ * Documentação de referência:
+ * </p>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_MS.html"> SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  * @author Leonardo Bessa
  * 
  */
 public class IEMatoGrossoDoSulValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("28(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("28(\\.\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("28\\d{7}");
-	
-    /**
+	public static final Pattern UNFORMATED = Pattern.compile("28\\d{7}");
+
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -47,7 +46,6 @@ public class IEMatoGrossoDoSulValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -58,14 +56,14 @@ public class IEMatoGrossoDoSulValidator extends AbstractIEValidator {
 		return FORMATED;
 	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -74,23 +72,12 @@ public class IEMatoGrossoDoSulValidator extends AbstractIEValidator {
 		return digitoPara.calcula();
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = "28" + new DigitoGenerator().generate(6);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoDoSulValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoDoSulValidator.java
@@ -19,66 +19,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEMatoGrossoDoSulValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("28(\\.\\d{3}){2}\\-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("28(\\.\\d{3}){2}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("28\\d{7}");
+    public static final Pattern UNFORMATED = Pattern.compile("28\\d{7}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEMatoGrossoDoSulValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEMatoGrossoDoSulValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEMatoGrossoDoSulValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEMatoGrossoDoSulValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEMatoGrossoDoSulValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEMatoGrossoDoSulValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = "28" + new DigitoGenerator().generate(6);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = "28" + new DigitoGenerator().generate(6);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.###.###-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoDoSulValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoDoSulValidator.java
@@ -19,66 +19,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEMatoGrossoDoSulValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("28(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("28(\\.\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("28\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("28\\d{7}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEMatoGrossoDoSulValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEMatoGrossoDoSulValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEMatoGrossoDoSulValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEMatoGrossoDoSulValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEMatoGrossoDoSulValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEMatoGrossoDoSulValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = "28" + new DigitoGenerator().generate(6);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.###.###-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = "28" + new DigitoGenerator().generate(6);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -13,11 +10,11 @@ import br.com.caelum.stella.validation.Validator;
 
 public class IEMatoGrossoValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{8,10}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{8,10}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9,11}");
-	
-    /**
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9,11}");
+
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -40,7 +37,6 @@ public class IEMatoGrossoValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -51,31 +47,20 @@ public class IEMatoGrossoValidator extends AbstractIEValidator {
 		return FORMATED;
 	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
 		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
 		return digitoPara.calcula();
-	}
-
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##########-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
 	}
 
 	/**
@@ -87,7 +72,7 @@ public class IEMatoGrossoValidator extends AbstractIEValidator {
 		final String ieSemDigito = new DigitoGenerator().generate(10);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##########-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoValidator.java
@@ -10,70 +10,70 @@ import br.com.caelum.stella.validation.Validator;
 
 public class IEMatoGrossoValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("\\d{8,10}\\-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("\\d{8,10}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("\\d{9,11}");
+    public static final Pattern UNFORMATED = Pattern.compile("\\d{9,11}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEMatoGrossoValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEMatoGrossoValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEMatoGrossoValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEMatoGrossoValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEMatoGrossoValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEMatoGrossoValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	/**
-	 * @see Validator#generateRandomValid()
-	 * @return uma inscrição estadual com 11 dígitos válida
-	 */
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = new DigitoGenerator().generate(10);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##########-#");
-		}
-		return ieComDigito;
-	}
+    /**
+     * @see Validator#generateRandomValid()
+     * @return uma inscrição estadual com 11 dígitos válida
+     */
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = new DigitoGenerator().generate(10);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##########-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMatoGrossoValidator.java
@@ -10,70 +10,70 @@ import br.com.caelum.stella.validation.Validator;
 
 public class IEMatoGrossoValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{8,10}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{8,10}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9,11}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9,11}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEMatoGrossoValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEMatoGrossoValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEMatoGrossoValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEMatoGrossoValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEMatoGrossoValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEMatoGrossoValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    /**
-     * @see Validator#generateRandomValid()
-     * @return uma inscrição estadual com 11 dígitos válida
-     */
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = new DigitoGenerator().generate(10);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##########-#");
-        }
-        return ieComDigito;
-    }
+	/**
+	 * @see Validator#generateRandomValid()
+	 * @return uma inscrição estadual com 11 dígitos válida
+	 */
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = new DigitoGenerator().generate(10);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##########-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMinasGeraisValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMinasGeraisValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -13,12 +10,11 @@ import br.com.caelum.stella.validation.Validator;
 
 public class IEMinasGeraisValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("(((\\d{3})\\.){2}\\d{3}/\\d{4})|(\\d{9}\\.\\d{2}-\\d{2})");
+	public static final Pattern FORMATED = Pattern.compile("(((\\d{3})\\.){2}\\d{3}/\\d{4})|(\\d{9}\\.\\d{2}-\\d{2})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(\\d{13})");
+	public static final Pattern UNFORMATED = Pattern.compile("(\\d{13})");
 
-	
-    /**
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -41,7 +37,6 @@ public class IEMinasGeraisValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -62,38 +57,27 @@ public class IEMinasGeraisValidator extends AbstractIEValidator {
 
 	private String calculaDigitos(String iESemDigito) {
 		String ieComZero = iESemDigito.substring(0, 3) + "0" + iESemDigito.substring(3);
-		String digito1 = new DigitoPara(ieComZero).complementarAoModulo().comMultiplicadores(2,1).somandoIndividualmente()
-									.mod(10).trocandoPorSeEncontrar("0", 10).calcula();
+		String digito1 = new DigitoPara(ieComZero).complementarAoModulo().comMultiplicadores(2, 1)
+				.somandoIndividualmente().mod(10).trocandoPorSeEncontrar("0", 10).calcula();
 
 		String digito2 = new DigitoPara(iESemDigito + digito1).complementarAoModulo().comMultiplicadoresDeAte(2, 11)
-									.trocandoPorSeEncontrar("0", 10, 11).calcula();
+				.trocandoPorSeEncontrar("0", 10, 11).calcula();
 
 		return digito1 + digito2;
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("###.###.###/####");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	/**
 	 * @see Validator#generateRandomValid()
-	 * @return uma inscrição estadual válida com 13 dígitos; se o validador estiver configurado para
-	 *         validar um número formatado, devolve o número gerado no formato
-	 *         <code>###.###.###/####</code>
+	 * @return uma inscrição estadual válida com 13 dígitos; se o validador estiver
+	 *         configurado para validar um número formatado, devolve o número gerado
+	 *         no formato <code>###.###.###/####</code>
 	 */
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigitos = new DigitoGenerator().generate(11);
 		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
 		if (isFormatted) {
-			return formata(ieComDigitos);
+			return super.format(ieComDigitos, "###.###.###/####");
 		}
 		return ieComDigitos;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMinasGeraisValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMinasGeraisValidator.java
@@ -10,75 +10,75 @@ import br.com.caelum.stella.validation.Validator;
 
 public class IEMinasGeraisValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("(((\\d{3})\\.){2}\\d{3}/\\d{4})|(\\d{9}\\.\\d{2}-\\d{2})");
+    public static final Pattern FORMATED = Pattern.compile("(((\\d{3})\\.){2}\\d{3}/\\d{4})|(\\d{9}\\.\\d{2}-\\d{2})");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(\\d{13})");
+    public static final Pattern UNFORMATED = Pattern.compile("(\\d{13})");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEMinasGeraisValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEMinasGeraisValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEMinasGeraisValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEMinasGeraisValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEMinasGeraisValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEMinasGeraisValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
-		String digitosCalculados = calculaDigitos(iESemDigito);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+        String digitosCalculados = calculaDigitos(iESemDigito);
 
-		return digitos.equals(digitosCalculados);
-	}
+        return digitos.equals(digitosCalculados);
+    }
 
-	private String calculaDigitos(String iESemDigito) {
-		String ieComZero = iESemDigito.substring(0, 3) + "0" + iESemDigito.substring(3);
-		String digito1 = new DigitoPara(ieComZero).complementarAoModulo().comMultiplicadores(2, 1)
-				.somandoIndividualmente().mod(10).trocandoPorSeEncontrar("0", 10).calcula();
+    private String calculaDigitos(String iESemDigito) {
+        String ieComZero = iESemDigito.substring(0, 3) + "0" + iESemDigito.substring(3);
+        String digito1 = new DigitoPara(ieComZero).complementarAoModulo().comMultiplicadores(2, 1)
+                .somandoIndividualmente().mod(10).trocandoPorSeEncontrar("0", 10).calcula();
 
-		String digito2 = new DigitoPara(iESemDigito + digito1).complementarAoModulo().comMultiplicadoresDeAte(2, 11)
-				.trocandoPorSeEncontrar("0", 10, 11).calcula();
+        String digito2 = new DigitoPara(iESemDigito + digito1).complementarAoModulo().comMultiplicadoresDeAte(2, 11)
+                .trocandoPorSeEncontrar("0", 10, 11).calcula();
 
-		return digito1 + digito2;
-	}
+        return digito1 + digito2;
+    }
 
-	/**
-	 * @see Validator#generateRandomValid()
-	 * @return uma inscrição estadual válida com 13 dígitos; se o validador estiver
-	 *         configurado para validar um número formatado, devolve o número gerado
-	 *         no formato <code>###.###.###/####</code>
-	 */
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigitos = new DigitoGenerator().generate(11);
-		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
-		if (isFormatted) {
-			return super.format(ieComDigitos, "###.###.###/####");
-		}
-		return ieComDigitos;
-	}
+    /**
+     * @see Validator#generateRandomValid()
+     * @return uma inscrição estadual válida com 13 dígitos; se o validador estiver
+     *         configurado para validar um número formatado, devolve o número gerado
+     *         no formato <code>###.###.###/####</code>
+     */
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigitos = new DigitoGenerator().generate(11);
+        final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
+        if (isFormatted) {
+            return super.format(ieComDigitos, "###.###.###/####");
+        }
+        return ieComDigitos;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMinasGeraisValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEMinasGeraisValidator.java
@@ -10,75 +10,75 @@ import br.com.caelum.stella.validation.Validator;
 
 public class IEMinasGeraisValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("(((\\d{3})\\.){2}\\d{3}/\\d{4})|(\\d{9}\\.\\d{2}-\\d{2})");
+	public static final Pattern FORMATED = Pattern.compile("(((\\d{3})\\.){2}\\d{3}/\\d{4})|(\\d{9}\\.\\d{2}-\\d{2})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(\\d{13})");
+	public static final Pattern UNFORMATED = Pattern.compile("(\\d{13})");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEMinasGeraisValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEMinasGeraisValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEMinasGeraisValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEMinasGeraisValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEMinasGeraisValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEMinasGeraisValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
-        String digitosCalculados = calculaDigitos(iESemDigito);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+		String digitosCalculados = calculaDigitos(iESemDigito);
 
-        return digitos.equals(digitosCalculados);
-    }
+		return digitos.equals(digitosCalculados);
+	}
 
-    private String calculaDigitos(String iESemDigito) {
-        String ieComZero = iESemDigito.substring(0, 3) + "0" + iESemDigito.substring(3);
-        String digito1 = new DigitoPara(ieComZero).complementarAoModulo().comMultiplicadores(2, 1)
-                .somandoIndividualmente().mod(10).trocandoPorSeEncontrar("0", 10).calcula();
+	private String calculaDigitos(String iESemDigito) {
+		String ieComZero = iESemDigito.substring(0, 3) + "0" + iESemDigito.substring(3);
+		String digito1 = new DigitoPara(ieComZero).complementarAoModulo().comMultiplicadores(2, 1)
+				.somandoIndividualmente().mod(10).trocandoPorSeEncontrar("0", 10).calcula();
 
-        String digito2 = new DigitoPara(iESemDigito + digito1).complementarAoModulo().comMultiplicadoresDeAte(2, 11)
-                .trocandoPorSeEncontrar("0", 10, 11).calcula();
+		String digito2 = new DigitoPara(iESemDigito + digito1).complementarAoModulo().comMultiplicadoresDeAte(2, 11)
+				.trocandoPorSeEncontrar("0", 10, 11).calcula();
 
-        return digito1 + digito2;
-    }
+		return digito1 + digito2;
+	}
 
-    /**
-     * @see Validator#generateRandomValid()
-     * @return uma inscrição estadual válida com 13 dígitos; se o validador estiver
-     *         configurado para validar um número formatado, devolve o número gerado
-     *         no formato <code>###.###.###/####</code>
-     */
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigitos = new DigitoGenerator().generate(11);
-        final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
-        if (isFormatted) {
-            return super.format(ieComDigitos, "###.###.###/####");
-        }
-        return ieComDigitos;
-    }
+	/**
+	 * @see Validator#generateRandomValid()
+	 * @return uma inscrição estadual válida com 13 dígitos; se o validador estiver
+	 *         configurado para validar um número formatado, devolve o número gerado
+	 *         no formato <code>###.###.###/####</code>
+	 */
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigitos = new DigitoGenerator().generate(11);
+		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
+		if (isFormatted) {
+			return super.format(ieComDigitos, "###.###.###/####");
+		}
+		return ieComDigitos;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -11,20 +8,21 @@ import br.com.caelum.stella.MessageProducer;
 import br.com.caelum.stella.SimpleMessageProducer;
 
 /**
- * <p> Documentação de referência: </p>
- * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_PA.html">
- * SINTEGRA - ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * <p>
+ * Documentação de referência:
+ * </p>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_PA.html"> SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  * @author Leonardo Bessa
  */
 public class IEParaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("15(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("15(\\.\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("15\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("15\\d{7}");
 
-	
-    /**
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -47,7 +45,6 @@ public class IEParaValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -58,14 +55,14 @@ public class IEParaValidator extends AbstractIEValidator {
 		return FORMATED;
 	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -74,23 +71,12 @@ public class IEParaValidator extends AbstractIEValidator {
 		return digitoPara.calcula();
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = "15" + new DigitoGenerator().generate(6);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaValidator.java
@@ -18,66 +18,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEParaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("15(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("15(\\.\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("15\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("15\\d{7}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEParaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEParaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEParaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEParaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEParaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEParaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = "15" + new DigitoGenerator().generate(6);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.###.###-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = "15" + new DigitoGenerator().generate(6);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaValidator.java
@@ -18,66 +18,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEParaValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("15(\\.\\d{3}){2}\\-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("15(\\.\\d{3}){2}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("15\\d{7}");
+    public static final Pattern UNFORMATED = Pattern.compile("15\\d{7}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEParaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEParaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEParaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEParaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEParaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEParaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = "15" + new DigitoGenerator().generate(6);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = "15" + new DigitoGenerator().generate(6);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.###.###-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaibaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaibaValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -11,20 +8,22 @@ import br.com.caelum.stella.MessageProducer;
 import br.com.caelum.stella.SimpleMessageProducer;
 
 /**
- * <p> Documentação de referência: </p>
- * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_PB.html">
- * SINTEGRA - ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * <p>
+ * Documentação de referência:
+ * </p>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_PB.html"> SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  * @author Leonardo Bessa
  * 
  */
 public class IEParaibaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
-	
-    /**
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -47,7 +46,6 @@ public class IEParaibaValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -58,14 +56,14 @@ public class IEParaibaValidator extends AbstractIEValidator {
 		return FORMATED;
 	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -74,23 +72,12 @@ public class IEParaibaValidator extends AbstractIEValidator {
 		return digitoPara.calcula();
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = new DigitoGenerator().generate(8);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaibaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaibaValidator.java
@@ -19,66 +19,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEParaibaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEParaibaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEParaibaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEParaibaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEParaibaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEParaibaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEParaibaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = new DigitoGenerator().generate(8);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.###.###-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = new DigitoGenerator().generate(8);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaibaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaibaValidator.java
@@ -19,66 +19,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEParaibaValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEParaibaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEParaibaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEParaibaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEParaibaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEParaibaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEParaibaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = new DigitoGenerator().generate(8);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = new DigitoGenerator().generate(8);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.###.###-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParanaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParanaValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -12,12 +9,11 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IEParanaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{3}\\.?\\d{5}\\-\\d{2}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{3}\\.?\\d{5}\\-\\d{2}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(\\d{10})");
+	public static final Pattern UNFORMATED = Pattern.compile("(\\d{10})");
 
-	
-    /**
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -40,7 +36,6 @@ public class IEParanaValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -51,14 +46,14 @@ public class IEParanaValidator extends AbstractIEValidator {
 		return FORMATED;
 	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
 		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
 
 		String digitosCalculados = calculaDigitos(iESemDigito);
 
 		return digitos.equals(digitosCalculados);
-    }
+	}
 
 	private String calculaDigitos(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -71,23 +66,12 @@ public class IEParanaValidator extends AbstractIEValidator {
 		return digito1 + digito2;
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("###.#####-##");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigitos = new DigitoGenerator().generate(8);
 		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
 		if (isFormatted) {
-			return formata(ieComDigitos);
+			return super.format(ieComDigitos, "###.#####-##");
 		}
 		return ieComDigitos;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParanaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParanaValidator.java
@@ -9,70 +9,70 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IEParanaValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("\\d{3}\\.?\\d{5}\\-\\d{2}");
+    public static final Pattern FORMATED = Pattern.compile("\\d{3}\\.?\\d{5}\\-\\d{2}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(\\d{10})");
+    public static final Pattern UNFORMATED = Pattern.compile("(\\d{10})");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEParanaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEParanaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEParanaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEParanaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEParanaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEParanaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
 
-		String digitosCalculados = calculaDigitos(iESemDigito);
+        String digitosCalculados = calculaDigitos(iESemDigito);
 
-		return digitos.equals(digitosCalculados);
-	}
+        return digitos.equals(digitosCalculados);
+    }
 
-	private String calculaDigitos(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.comMultiplicadoresDeAte(2, 7).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigitos(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.comMultiplicadoresDeAte(2, 7).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		String digito1 = digitoPara.calcula();
-		digitoPara.addDigito(digito1);
-		String digito2 = digitoPara.calcula();
+        String digito1 = digitoPara.calcula();
+        digitoPara.addDigito(digito1);
+        String digito2 = digitoPara.calcula();
 
-		return digito1 + digito2;
-	}
+        return digito1 + digito2;
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigitos = new DigitoGenerator().generate(8);
-		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
-		if (isFormatted) {
-			return super.format(ieComDigitos, "###.#####-##");
-		}
-		return ieComDigitos;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigitos = new DigitoGenerator().generate(8);
+        final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
+        if (isFormatted) {
+            return super.format(ieComDigitos, "###.#####-##");
+        }
+        return ieComDigitos;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParanaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParanaValidator.java
@@ -9,70 +9,70 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IEParanaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{3}\\.?\\d{5}\\-\\d{2}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{3}\\.?\\d{5}\\-\\d{2}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(\\d{10})");
+	public static final Pattern UNFORMATED = Pattern.compile("(\\d{10})");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEParanaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEParanaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEParanaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEParanaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEParanaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEParanaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
 
-        String digitosCalculados = calculaDigitos(iESemDigito);
+		String digitosCalculados = calculaDigitos(iESemDigito);
 
-        return digitos.equals(digitosCalculados);
-    }
+		return digitos.equals(digitosCalculados);
+	}
 
-    private String calculaDigitos(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.comMultiplicadoresDeAte(2, 7).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigitos(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.comMultiplicadoresDeAte(2, 7).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        String digito1 = digitoPara.calcula();
-        digitoPara.addDigito(digito1);
-        String digito2 = digitoPara.calcula();
+		String digito1 = digitoPara.calcula();
+		digitoPara.addDigito(digito1);
+		String digito2 = digitoPara.calcula();
 
-        return digito1 + digito2;
-    }
+		return digito1 + digito2;
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigitos = new DigitoGenerator().generate(8);
-        final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
-        if (isFormatted) {
-            return super.format(ieComDigitos, "###.#####-##");
-        }
-        return ieComDigitos;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigitos = new DigitoGenerator().generate(8);
+		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
+		if (isFormatted) {
+			return super.format(ieComDigitos, "###.#####-##");
+		}
+		return ieComDigitos;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoAntigaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoAntigaValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -12,11 +9,11 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 class IEPernambucoAntigaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("([1][8])\\.?([1-9])\\.?(\\d{3})\\.?(\\d{7})\\-?(\\d{1})");
+	public static final Pattern FORMATED = Pattern.compile("([1][8])\\.?([1-9])\\.?(\\d{3})\\.?(\\d{7})\\-?(\\d{1})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("([1][8])([1-9])(\\d{3})(\\d{7})(\\d{1})");
-	
-    /**
+	public static final Pattern UNFORMATED = Pattern.compile("([1][8])([1-9])(\\d{3})(\\d{7})(\\d{1})");
+
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -39,7 +36,6 @@ class IEPernambucoAntigaValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -60,18 +56,7 @@ class IEPernambucoAntigaValidator extends AbstractIEValidator {
 
 	private String calculaDigito(String iESemDigito) {
 		return new DigitoPara(iESemDigito + "0").comMultiplicadoresDeAte(1, 9).complementarAoModulo()
-						.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
-	}
-
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.#.###.#######-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
+				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
 	}
 
 	@Override
@@ -79,7 +64,7 @@ class IEPernambucoAntigaValidator extends AbstractIEValidator {
 		final String ieSemDigito = "18" + new DigitoGenerator().generate(11);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return format(ieComDigito, "##.#.###.#######-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoAntigaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoAntigaValidator.java
@@ -9,63 +9,63 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 class IEPernambucoAntigaValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("([1][8])\\.?([1-9])\\.?(\\d{3})\\.?(\\d{7})\\-?(\\d{1})");
+    public static final Pattern FORMATED = Pattern.compile("([1][8])\\.?([1-9])\\.?(\\d{3})\\.?(\\d{7})\\-?(\\d{1})");
 
-	public static final Pattern UNFORMATED = Pattern.compile("([1][8])([1-9])(\\d{3})(\\d{7})(\\d{1})");
+    public static final Pattern UNFORMATED = Pattern.compile("([1][8])([1-9])(\\d{3})(\\d{7})(\\d{1})");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEPernambucoAntigaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEPernambucoAntigaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEPernambucoAntigaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEPernambucoAntigaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEPernambucoAntigaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEPernambucoAntigaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
-		String digitoCalculado = calculaDigito(iESemDigito);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		return new DigitoPara(iESemDigito + "0").comMultiplicadoresDeAte(1, 9).complementarAoModulo()
-				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
-	}
+    private String calculaDigito(String iESemDigito) {
+        return new DigitoPara(iESemDigito + "0").comMultiplicadoresDeAte(1, 9).complementarAoModulo()
+                .trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = "18" + new DigitoGenerator().generate(11);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return format(ieComDigito, "##.#.###.#######-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = "18" + new DigitoGenerator().generate(11);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return format(ieComDigito, "##.#.###.#######-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoAntigaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoAntigaValidator.java
@@ -9,63 +9,63 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 class IEPernambucoAntigaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("([1][8])\\.?([1-9])\\.?(\\d{3})\\.?(\\d{7})\\-?(\\d{1})");
+	public static final Pattern FORMATED = Pattern.compile("([1][8])\\.?([1-9])\\.?(\\d{3})\\.?(\\d{7})\\-?(\\d{1})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("([1][8])([1-9])(\\d{3})(\\d{7})(\\d{1})");
+	public static final Pattern UNFORMATED = Pattern.compile("([1][8])([1-9])(\\d{3})(\\d{7})(\\d{1})");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEPernambucoAntigaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEPernambucoAntigaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEPernambucoAntigaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEPernambucoAntigaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEPernambucoAntigaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEPernambucoAntigaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
-        String digitoCalculado = calculaDigito(iESemDigito);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        return new DigitoPara(iESemDigito + "0").comMultiplicadoresDeAte(1, 9).complementarAoModulo()
-                .trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
-    }
+	private String calculaDigito(String iESemDigito) {
+		return new DigitoPara(iESemDigito + "0").comMultiplicadoresDeAte(1, 9).complementarAoModulo()
+				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = "18" + new DigitoGenerator().generate(11);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return format(ieComDigito, "##.#.###.#######-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = "18" + new DigitoGenerator().generate(11);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return format(ieComDigito, "##.#.###.#######-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoNovaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoNovaValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -12,13 +9,12 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 class IEPernambucoNovaValidator extends AbstractIEValidator {
 
-    // 0321418-40
-    public static final Pattern FORMATED = Pattern.compile("(\\d{7})[-](\\d{2})");
+	// 0321418-40
+	public static final Pattern FORMATED = Pattern.compile("(\\d{7})[-](\\d{2})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(\\d{7})(\\d{2})");
+	public static final Pattern UNFORMATED = Pattern.compile("(\\d{7})(\\d{2})");
 
-	
-    /**
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -40,7 +36,6 @@ class IEPernambucoNovaValidator extends AbstractIEValidator {
 	public IEPernambucoNovaValidator(MessageProducer messageProducer, boolean isFormatted) {
 		super(messageProducer, isFormatted);
 	}
-
 
 	@Override
 	protected Pattern getUnformattedPattern() {
@@ -71,23 +66,12 @@ class IEPernambucoNovaValidator extends AbstractIEValidator {
 		return digito1 + digito2;
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("#######-##");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigitos = new DigitoGenerator().generate(7);
 		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
 		if (isFormatted) {
-			return formata(ieComDigitos);
+			return super.format(ieComDigitos, "#######-##");
 		}
 		return ieComDigitos;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoNovaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoNovaValidator.java
@@ -9,70 +9,70 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 class IEPernambucoNovaValidator extends AbstractIEValidator {
 
-    // 0321418-40
-    public static final Pattern FORMATED = Pattern.compile("(\\d{7})[-](\\d{2})");
+	// 0321418-40
+	public static final Pattern FORMATED = Pattern.compile("(\\d{7})[-](\\d{2})");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(\\d{7})(\\d{2})");
+	public static final Pattern UNFORMATED = Pattern.compile("(\\d{7})(\\d{2})");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEPernambucoNovaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEPernambucoNovaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEPernambucoNovaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEPernambucoNovaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEPernambucoNovaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEPernambucoNovaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
-        String digitosCalculados = calculaDigitos(iESemDigito);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+		String digitosCalculados = calculaDigitos(iESemDigito);
 
-        return digitos.equals(digitosCalculados);
-    }
+		return digitos.equals(digitosCalculados);
+	}
 
-    private String calculaDigitos(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigitos(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        String digito1 = digitoPara.calcula();
-        digitoPara.addDigito(digito1);
-        String digito2 = digitoPara.calcula();
+		String digito1 = digitoPara.calcula();
+		digitoPara.addDigito(digito1);
+		String digito2 = digitoPara.calcula();
 
-        return digito1 + digito2;
-    }
+		return digito1 + digito2;
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigitos = new DigitoGenerator().generate(7);
-        final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
-        if (isFormatted) {
-            return super.format(ieComDigitos, "#######-##");
-        }
-        return ieComDigitos;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigitos = new DigitoGenerator().generate(7);
+		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
+		if (isFormatted) {
+			return super.format(ieComDigitos, "#######-##");
+		}
+		return ieComDigitos;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoNovaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoNovaValidator.java
@@ -9,70 +9,70 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 class IEPernambucoNovaValidator extends AbstractIEValidator {
 
-	// 0321418-40
-	public static final Pattern FORMATED = Pattern.compile("(\\d{7})[-](\\d{2})");
+    // 0321418-40
+    public static final Pattern FORMATED = Pattern.compile("(\\d{7})[-](\\d{2})");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(\\d{7})(\\d{2})");
+    public static final Pattern UNFORMATED = Pattern.compile("(\\d{7})(\\d{2})");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEPernambucoNovaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEPernambucoNovaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEPernambucoNovaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEPernambucoNovaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEPernambucoNovaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEPernambucoNovaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
-		String digitos = unformattedIE.substring(unformattedIE.length() - 2);
-		String digitosCalculados = calculaDigitos(iESemDigito);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 2);
+        String digitos = unformattedIE.substring(unformattedIE.length() - 2);
+        String digitosCalculados = calculaDigitos(iESemDigito);
 
-		return digitos.equals(digitosCalculados);
-	}
+        return digitos.equals(digitosCalculados);
+    }
 
-	private String calculaDigitos(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigitos(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		String digito1 = digitoPara.calcula();
-		digitoPara.addDigito(digito1);
-		String digito2 = digitoPara.calcula();
+        String digito1 = digitoPara.calcula();
+        digitoPara.addDigito(digito1);
+        String digito2 = digitoPara.calcula();
 
-		return digito1 + digito2;
-	}
+        return digito1 + digito2;
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigitos = new DigitoGenerator().generate(7);
-		final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
-		if (isFormatted) {
-			return super.format(ieComDigitos, "#######-##");
-		}
-		return ieComDigitos;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigitos = new DigitoGenerator().generate(7);
+        final String ieComDigitos = ieSemDigitos + calculaDigitos(ieSemDigitos);
+        if (isFormatted) {
+            return super.format(ieComDigitos, "#######-##");
+        }
+        return ieComDigitos;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoValidator.java
@@ -8,66 +8,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
 import br.com.caelum.stella.ValidationMessage;
 import br.com.caelum.stella.validation.LogicOrComposedValidator;
 import br.com.caelum.stella.validation.Validator;
-import br.com.caelum.stella.validation.error.IEError;	
+import br.com.caelum.stella.validation.error.IEError;
 
 public class IEPernambucoValidator implements Validator<String> {
 
-	private final LogicOrComposedValidator<String> baseValidator;
+    private final LogicOrComposedValidator<String> baseValidator;
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEPernambucoValidator() {
-		this(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEPernambucoValidator() {
+        this(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEPernambucoValidator(boolean isFormatted) {
-		this(new SimpleMessageProducer(), isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEPernambucoValidator(boolean isFormatted) {
+        this(new SimpleMessageProducer(), isFormatted);
+    }
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public IEPernambucoValidator(MessageProducer messageProducer, boolean isFormatted) {
-		Class[] validatorClasses = { IEPernambucoNovaValidator.class, IEPernambucoAntigaValidator.class };
-		this.baseValidator = new LogicOrComposedValidator<String>(messageProducer, isFormatted, validatorClasses);
-		this.baseValidator.setInvalidFormat(IEError.INVALID_FORMAT);
-	}
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public IEPernambucoValidator(MessageProducer messageProducer, boolean isFormatted) {
+        Class[] validatorClasses = { IEPernambucoNovaValidator.class, IEPernambucoAntigaValidator.class };
+        this.baseValidator = new LogicOrComposedValidator<String>(messageProducer, isFormatted, validatorClasses);
+        this.baseValidator.setInvalidFormat(IEError.INVALID_FORMAT);
+    }
 
-	public void assertValid(String value) {
-		if (value != null) {
-			baseValidator.assertValid(value);
-		}
-	}
+    public void assertValid(String value) {
+        if (value != null) {
+            baseValidator.assertValid(value);
+        }
+    }
 
-	public List<ValidationMessage> invalidMessagesFor(String value) {
-		List<ValidationMessage> result;
-		if (value != null) {
-			result = baseValidator.invalidMessagesFor(value);
-		} else {
-			result = new ArrayList<ValidationMessage>();
-		}
-		return result;
-	}
+    public List<ValidationMessage> invalidMessagesFor(String value) {
+        List<ValidationMessage> result;
+        if (value != null) {
+            result = baseValidator.invalidMessagesFor(value);
+        } else {
+            result = new ArrayList<ValidationMessage>();
+        }
+        return result;
+    }
 
-	public boolean isEligible(String object) {
-		return baseValidator.isEligible(object);
-	}
+    public boolean isEligible(String object) {
+        return baseValidator.isEligible(object);
+    }
 
-	/**
-	 * @see Validator#generateRandomValid()
-	 * @see LogicOrComposedValidator#generateRandomValid()
-	 * @return uma inscrição estadual válida de acordo com o novo padrão de
-	 *         Pernambuco
-	 */
-	@Override
-	public String generateRandomValid() {
-		return baseValidator.generateRandomValid();
-	}
+    /**
+     * @see Validator#generateRandomValid()
+     * @see LogicOrComposedValidator#generateRandomValid()
+     * @return uma inscrição estadual válida de acordo com o novo padrão de
+     *         Pernambuco
+     */
+    @Override
+    public String generateRandomValid() {
+        return baseValidator.generateRandomValid();
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoValidator.java
@@ -12,62 +12,62 @@ import br.com.caelum.stella.validation.error.IEError;
 
 public class IEPernambucoValidator implements Validator<String> {
 
-    private final LogicOrComposedValidator<String> baseValidator;
+	private final LogicOrComposedValidator<String> baseValidator;
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEPernambucoValidator() {
-        this(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEPernambucoValidator() {
+		this(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEPernambucoValidator(boolean isFormatted) {
-        this(new SimpleMessageProducer(), isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEPernambucoValidator(boolean isFormatted) {
+		this(new SimpleMessageProducer(), isFormatted);
+	}
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public IEPernambucoValidator(MessageProducer messageProducer, boolean isFormatted) {
-        Class[] validatorClasses = { IEPernambucoNovaValidator.class, IEPernambucoAntigaValidator.class };
-        this.baseValidator = new LogicOrComposedValidator<String>(messageProducer, isFormatted, validatorClasses);
-        this.baseValidator.setInvalidFormat(IEError.INVALID_FORMAT);
-    }
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public IEPernambucoValidator(MessageProducer messageProducer, boolean isFormatted) {
+		Class[] validatorClasses = { IEPernambucoNovaValidator.class, IEPernambucoAntigaValidator.class };
+		this.baseValidator = new LogicOrComposedValidator<String>(messageProducer, isFormatted, validatorClasses);
+		this.baseValidator.setInvalidFormat(IEError.INVALID_FORMAT);
+	}
 
-    public void assertValid(String value) {
-        if (value != null) {
-            baseValidator.assertValid(value);
-        }
-    }
+	public void assertValid(String value) {
+		if (value != null) {
+			baseValidator.assertValid(value);
+		}
+	}
 
-    public List<ValidationMessage> invalidMessagesFor(String value) {
-        List<ValidationMessage> result;
-        if (value != null) {
-            result = baseValidator.invalidMessagesFor(value);
-        } else {
-            result = new ArrayList<ValidationMessage>();
-        }
-        return result;
-    }
+	public List<ValidationMessage> invalidMessagesFor(String value) {
+		List<ValidationMessage> result;
+		if (value != null) {
+			result = baseValidator.invalidMessagesFor(value);
+		} else {
+			result = new ArrayList<ValidationMessage>();
+		}
+		return result;
+	}
 
-    public boolean isEligible(String object) {
-        return baseValidator.isEligible(object);
-    }
+	public boolean isEligible(String object) {
+		return baseValidator.isEligible(object);
+	}
 
-    /**
-     * @see Validator#generateRandomValid()
-     * @see LogicOrComposedValidator#generateRandomValid()
-     * @return uma inscrição estadual válida de acordo com o novo padrão de
-     *         Pernambuco
-     */
-    @Override
-    public String generateRandomValid() {
-        return baseValidator.generateRandomValid();
-    }
+	/**
+	 * @see Validator#generateRandomValid()
+	 * @see LogicOrComposedValidator#generateRandomValid()
+	 * @return uma inscrição estadual válida de acordo com o novo padrão de
+	 *         Pernambuco
+	 */
+	@Override
+	public String generateRandomValid() {
+		return baseValidator.generateRandomValid();
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPernambucoValidator.java
@@ -1,73 +1,70 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.text.MaskFormatter;
-
-import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.MessageProducer;
 import br.com.caelum.stella.SimpleMessageProducer;
 import br.com.caelum.stella.ValidationMessage;
 import br.com.caelum.stella.validation.LogicOrComposedValidator;
 import br.com.caelum.stella.validation.Validator;
-import br.com.caelum.stella.validation.error.IEError;
+import br.com.caelum.stella.validation.error.IEError;	
 
 public class IEPernambucoValidator implements Validator<String> {
 
-    private final LogicOrComposedValidator<String> baseValidator;
+	private final LogicOrComposedValidator<String> baseValidator;
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEPernambucoValidator() {
-        this(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEPernambucoValidator() {
+		this(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEPernambucoValidator(boolean isFormatted) {
-        this(new SimpleMessageProducer(), isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEPernambucoValidator(boolean isFormatted) {
+		this(new SimpleMessageProducer(), isFormatted);
+	}
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public IEPernambucoValidator(MessageProducer messageProducer, boolean isFormatted) {
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public IEPernambucoValidator(MessageProducer messageProducer, boolean isFormatted) {
 		Class[] validatorClasses = { IEPernambucoNovaValidator.class, IEPernambucoAntigaValidator.class };
-        this.baseValidator = new LogicOrComposedValidator<String>(messageProducer, isFormatted, validatorClasses);
-        this.baseValidator.setInvalidFormat(IEError.INVALID_FORMAT);
-    }
+		this.baseValidator = new LogicOrComposedValidator<String>(messageProducer, isFormatted, validatorClasses);
+		this.baseValidator.setInvalidFormat(IEError.INVALID_FORMAT);
+	}
 
-    public void assertValid(String value) {
-        if (value != null) {
-            baseValidator.assertValid(value);
-        }
-    }
+	public void assertValid(String value) {
+		if (value != null) {
+			baseValidator.assertValid(value);
+		}
+	}
 
-    public List<ValidationMessage> invalidMessagesFor(String value) {
-        List<ValidationMessage> result;
-        if (value != null) {
-            result = baseValidator.invalidMessagesFor(value);
-        } else {
-            result = new ArrayList<ValidationMessage>();
-        }
-        return result;
-    }
+	public List<ValidationMessage> invalidMessagesFor(String value) {
+		List<ValidationMessage> result;
+		if (value != null) {
+			result = baseValidator.invalidMessagesFor(value);
+		} else {
+			result = new ArrayList<ValidationMessage>();
+		}
+		return result;
+	}
 
-    public boolean isEligible(String object) {
-        return baseValidator.isEligible(object);
-    }
+	public boolean isEligible(String object) {
+		return baseValidator.isEligible(object);
+	}
 
-    /**
+	/**
 	 * @see Validator#generateRandomValid()
 	 * @see LogicOrComposedValidator#generateRandomValid()
-	 * @return uma inscrição estadual válida de acordo com o novo padrão de Pernambuco
+	 * @return uma inscrição estadual válida de acordo com o novo padrão de
+	 *         Pernambuco
 	 */
 	@Override
 	public String generateRandomValid() {

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPiauiValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPiauiValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -11,20 +8,21 @@ import br.com.caelum.stella.MessageProducer;
 import br.com.caelum.stella.SimpleMessageProducer;
 
 /**
- * <p> Documentação de referência: </p>
- * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_PI.html">
- * SINTEGRA - ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * <p>
+ * Documentação de referência:
+ * </p>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_PI.html"> SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  * @author Leonardo Bessa
  */
 public class IEPiauiValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-	
-    /**
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -47,7 +45,6 @@ public class IEPiauiValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -58,14 +55,14 @@ public class IEPiauiValidator extends AbstractIEValidator {
 		return FORMATED;
 	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -74,23 +71,12 @@ public class IEPiauiValidator extends AbstractIEValidator {
 		return digitoPara.calcula();
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = new DigitoGenerator().generate(8);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPiauiValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPiauiValidator.java
@@ -18,66 +18,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEPiauiValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IEPiauiValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IEPiauiValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IEPiauiValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IEPiauiValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IEPiauiValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IEPiauiValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = new DigitoGenerator().generate(8);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = new DigitoGenerator().generate(8);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.###.###-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPiauiValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEPiauiValidator.java
@@ -18,66 +18,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEPiauiValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IEPiauiValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IEPiauiValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IEPiauiValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IEPiauiValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IEPiauiValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IEPiauiValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = new DigitoGenerator().generate(8);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.###.###-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = new DigitoGenerator().generate(8);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioDeJaneiroValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioDeJaneiroValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -12,12 +9,11 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IERioDeJaneiroValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{8}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{8}");
 
-	
-    /**
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -40,7 +36,6 @@ public class IERioDeJaneiroValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -51,14 +46,14 @@ public class IERioDeJaneiroValidator extends AbstractIEValidator {
 		return FORMATED;
 	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -67,23 +62,12 @@ public class IERioDeJaneiroValidator extends AbstractIEValidator {
 		return digitoPara.calcula();
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = new DigitoGenerator().generate(7);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.###.###");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioDeJaneiroValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioDeJaneiroValidator.java
@@ -9,66 +9,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IERioDeJaneiroValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{8}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{8}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IERioDeJaneiroValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IERioDeJaneiroValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IERioDeJaneiroValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IERioDeJaneiroValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IERioDeJaneiroValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IERioDeJaneiroValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.comMultiplicadoresDeAte(2, 7).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.comMultiplicadoresDeAte(2, 7).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = new DigitoGenerator().generate(7);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.###.###");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = new DigitoGenerator().generate(7);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.###.###");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioDeJaneiroValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioDeJaneiroValidator.java
@@ -9,66 +9,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IERioDeJaneiroValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}");
+    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("\\d{8}");
+    public static final Pattern UNFORMATED = Pattern.compile("\\d{8}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IERioDeJaneiroValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IERioDeJaneiroValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IERioDeJaneiroValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IERioDeJaneiroValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IERioDeJaneiroValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IERioDeJaneiroValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.comMultiplicadoresDeAte(2, 7).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.comMultiplicadoresDeAte(2, 7).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = new DigitoGenerator().generate(7);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = new DigitoGenerator().generate(7);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.###.###");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoNorteValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoNorteValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -12,19 +9,21 @@ import br.com.caelum.stella.SimpleMessageProducer;
 import br.com.caelum.stella.validation.Validator;
 
 /**
- * <p> Documentação de referência: </p>
- * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_RN.html">
- * SINTEGRA - ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
+ * <p>
+ * Documentação de referência:
+ * </p>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_RN.html"> SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a>
  * 
  * @author Leonardo Bessa
  */
 public class IERioGrandeDoNorteValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("20\\.(\\d\\.)?\\d{3}\\.\\d{3}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("20\\.(\\d\\.)?\\d{3}\\.\\d{3}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("20\\d{7,8}");
-	
-    /**
+	public static final Pattern UNFORMATED = Pattern.compile("20\\d{7,8}");
+
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -47,7 +46,6 @@ public class IERioGrandeDoNorteValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -67,18 +65,8 @@ public class IERioGrandeDoNorteValidator extends AbstractIEValidator {
 	}
 
 	private String calculaDigito(String iESemDigito) {
-		return new DigitoPara(iESemDigito).comMultiplicadoresDeAte(2, 10).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11).calcula();
-	}
-
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.#.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
+		return new DigitoPara(iESemDigito).comMultiplicadoresDeAte(2, 10).complementarAoModulo()
+				.trocandoPorSeEncontrar("0", 10, 11).calcula();
 	}
 
 	/**
@@ -90,7 +78,7 @@ public class IERioGrandeDoNorteValidator extends AbstractIEValidator {
 		final String ieSemDigito = "20" + new DigitoGenerator().generate(7);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.#.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoNorteValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoNorteValidator.java
@@ -19,67 +19,67 @@ import br.com.caelum.stella.validation.Validator;
  */
 public class IERioGrandeDoNorteValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("20\\.(\\d\\.)?\\d{3}\\.\\d{3}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("20\\.(\\d\\.)?\\d{3}\\.\\d{3}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("20\\d{7,8}");
+	public static final Pattern UNFORMATED = Pattern.compile("20\\d{7,8}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IERioGrandeDoNorteValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IERioGrandeDoNorteValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IERioGrandeDoNorteValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IERioGrandeDoNorteValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IERioGrandeDoNorteValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IERioGrandeDoNorteValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
-        String digitoCalculado = calculaDigito(iESemDigito);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        return new DigitoPara(iESemDigito).comMultiplicadoresDeAte(2, 10).complementarAoModulo()
-                .trocandoPorSeEncontrar("0", 10, 11).calcula();
-    }
+	private String calculaDigito(String iESemDigito) {
+		return new DigitoPara(iESemDigito).comMultiplicadoresDeAte(2, 10).complementarAoModulo()
+				.trocandoPorSeEncontrar("0", 10, 11).calcula();
+	}
 
-    /**
-     * @see Validator#generateRandomValid()
-     * @return uma inscrição estadual válida com 10 dígitos
-     */
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = "20" + new DigitoGenerator().generate(7);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.#.###.###-#");
-        }
-        return ieComDigito;
-    }
+	/**
+	 * @see Validator#generateRandomValid()
+	 * @return uma inscrição estadual válida com 10 dígitos
+	 */
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = "20" + new DigitoGenerator().generate(7);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.#.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoNorteValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoNorteValidator.java
@@ -19,67 +19,67 @@ import br.com.caelum.stella.validation.Validator;
  */
 public class IERioGrandeDoNorteValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("20\\.(\\d\\.)?\\d{3}\\.\\d{3}\\-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("20\\.(\\d\\.)?\\d{3}\\.\\d{3}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("20\\d{7,8}");
+    public static final Pattern UNFORMATED = Pattern.compile("20\\d{7,8}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IERioGrandeDoNorteValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IERioGrandeDoNorteValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IERioGrandeDoNorteValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IERioGrandeDoNorteValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IERioGrandeDoNorteValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IERioGrandeDoNorteValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
-		String digitoCalculado = calculaDigito(iESemDigito);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		return new DigitoPara(iESemDigito).comMultiplicadoresDeAte(2, 10).complementarAoModulo()
-				.trocandoPorSeEncontrar("0", 10, 11).calcula();
-	}
+    private String calculaDigito(String iESemDigito) {
+        return new DigitoPara(iESemDigito).comMultiplicadoresDeAte(2, 10).complementarAoModulo()
+                .trocandoPorSeEncontrar("0", 10, 11).calcula();
+    }
 
-	/**
-	 * @see Validator#generateRandomValid()
-	 * @return uma inscrição estadual válida com 10 dígitos
-	 */
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = "20" + new DigitoGenerator().generate(7);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.#.###.###-#");
-		}
-		return ieComDigito;
-	}
+    /**
+     * @see Validator#generateRandomValid()
+     * @return uma inscrição estadual válida com 10 dígitos
+     */
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = "20" + new DigitoGenerator().generate(7);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.#.###.###-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoSulValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoSulValidator.java
@@ -1,12 +1,9 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -15,80 +12,79 @@ import br.com.caelum.stella.SimpleMessageProducer;
 import br.com.caelum.stella.ValidationMessage;
 import br.com.caelum.stella.validation.BaseValidator;
 import br.com.caelum.stella.validation.InvalidValue;
-import br.com.caelum.stella.validation.Validator;
 import br.com.caelum.stella.validation.error.IEError;
 
-public class IERioGrandeDoSulValidator implements Validator<String> {
+public class IERioGrandeDoSulValidator extends AbstractIEValidator {
 
-    private final boolean isFormatted;
+	private final boolean isFormatted;
 
-    public static final Pattern FORMATED = Pattern.compile("[0-4]\\d{2}\\/\\d{7}");
+	public static final Pattern FORMATED = Pattern.compile("[0-4]\\d{2}\\/\\d{7}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("([0-4]\\d{2})\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("([0-4]\\d{2})\\d{7}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IERioGrandeDoSulValidator() {
-        this(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IERioGrandeDoSulValidator() {
+		this(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IERioGrandeDoSulValidator(boolean isFormatted) {
-        this.baseValidator = new BaseValidator();
-        this.isFormatted = isFormatted;
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IERioGrandeDoSulValidator(boolean isFormatted) {
+		this.baseValidator = new BaseValidator();
+		this.isFormatted = isFormatted;
+	}
 
-    public IERioGrandeDoSulValidator(MessageProducer messageProducer, boolean isFormatted) {
-        this.baseValidator = new BaseValidator(messageProducer);
-        this.isFormatted = isFormatted;
-    }
+	public IERioGrandeDoSulValidator(MessageProducer messageProducer, boolean isFormatted) {
+		this.baseValidator = new BaseValidator(messageProducer);
+		this.isFormatted = isFormatted;
+	}
 
-    private List<InvalidValue> getInvalidValues(String IE) {
-        List<InvalidValue> errors = new ArrayList<InvalidValue>();
-        errors.clear();
-        if (IE != null) {
-            String unformatedIE = checkForCorrectFormat(IE, errors);
-            if (errors.isEmpty()) {
-                if (!hasValidCheckDigits(unformatedIE)) {
-                    errors.add(IEError.INVALID_CHECK_DIGITS);
-                }
-            }
-        }
-        return errors;
-    }
+	private List<InvalidValue> getInvalidValues(String IE) {
+		List<InvalidValue> errors = new ArrayList<InvalidValue>();
+		errors.clear();
+		if (IE != null) {
+			String unformatedIE = checkForCorrectFormat(IE, errors);
+			if (errors.isEmpty()) {
+				if (!hasValidCheckDigits(unformatedIE)) {
+					errors.add(IEError.INVALID_CHECK_DIGITS);
+				}
+			}
+		}
+		return errors;
+	}
 
-    private String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
-        String unformatedIE = null;
-        if (isFormatted) {
-            if (!(FORMATED.matcher(ie).matches())) {
-                errors.add(IEError.INVALID_FORMAT);
-            }
-            unformatedIE = ie.replaceAll("\\D", "");
-        } else {
-            if (!UNFORMATED.matcher(ie).matches()) {
-                errors.add(IEError.INVALID_DIGITS);
-            }
-            unformatedIE = ie;
-        }
-        return unformatedIE;
-    }
+	protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
+		String unformatedIE = null;
+		if (isFormatted) {
+			if (!(FORMATED.matcher(ie).matches())) {
+				errors.add(IEError.INVALID_FORMAT);
+			}
+			unformatedIE = ie.replaceAll("\\D", "");
+		} else {
+			if (!UNFORMATED.matcher(ie).matches()) {
+				errors.add(IEError.INVALID_DIGITS);
+			}
+			unformatedIE = ie;
+		}
+		return unformatedIE;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -97,45 +93,45 @@ public class IERioGrandeDoSulValidator implements Validator<String> {
 		return digitoPara.calcula();
 	}
 
-    public boolean isEligible(String value) {
-        boolean result;
-        if (isFormatted) {
-            result = FORMATED.matcher(value).matches();
-        } else {
-            result = UNFORMATED.matcher(value).matches();
-        }
-        return result;
-    }
-
-    private final BaseValidator baseValidator;
-
-    public void assertValid(String cpf) {
-        baseValidator.assertValid(getInvalidValues(cpf));
-    }
-
-    public List<ValidationMessage> invalidMessagesFor(String cpf) {
-        return baseValidator.generateValidationMessages(getInvalidValues(cpf));
-    }
-
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("###/#######");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
+	public boolean isEligible(String value) {
+		boolean result;
+		if (isFormatted) {
+			result = FORMATED.matcher(value).matches();
+		} else {
+			result = UNFORMATED.matcher(value).matches();
 		}
+		return result;
 	}
-	
+
+	private final BaseValidator baseValidator;
+
+	public void assertValid(String cpf) {
+		baseValidator.assertValid(getInvalidValues(cpf));
+	}
+
+	public List<ValidationMessage> invalidMessagesFor(String cpf) {
+		return baseValidator.generateValidationMessages(getInvalidValues(cpf));
+	}
+
 	@Override
 	public String generateRandomValid() {
 		final String primeiroDigito = String.valueOf(new Random().nextInt(5));
 		final String ieSemDigito = primeiroDigito + new DigitoGenerator().generate(8);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "###/#######");
 		}
 		return ieComDigito;
+	}
+
+
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
+
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
 	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoSulValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoSulValidator.java
@@ -16,122 +16,121 @@ import br.com.caelum.stella.validation.error.IEError;
 
 public class IERioGrandeDoSulValidator extends AbstractIEValidator {
 
-	private final boolean isFormatted;
+    private final boolean isFormatted;
 
-	public static final Pattern FORMATED = Pattern.compile("[0-4]\\d{2}\\/\\d{7}");
+    public static final Pattern FORMATED = Pattern.compile("[0-4]\\d{2}\\/\\d{7}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("([0-4]\\d{2})\\d{7}");
+    public static final Pattern UNFORMATED = Pattern.compile("([0-4]\\d{2})\\d{7}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IERioGrandeDoSulValidator() {
-		this(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IERioGrandeDoSulValidator() {
+        this(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IERioGrandeDoSulValidator(boolean isFormatted) {
-		this.baseValidator = new BaseValidator();
-		this.isFormatted = isFormatted;
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IERioGrandeDoSulValidator(boolean isFormatted) {
+        this.baseValidator = new BaseValidator();
+        this.isFormatted = isFormatted;
+    }
 
-	public IERioGrandeDoSulValidator(MessageProducer messageProducer, boolean isFormatted) {
-		this.baseValidator = new BaseValidator(messageProducer);
-		this.isFormatted = isFormatted;
-	}
+    public IERioGrandeDoSulValidator(MessageProducer messageProducer, boolean isFormatted) {
+        this.baseValidator = new BaseValidator(messageProducer);
+        this.isFormatted = isFormatted;
+    }
 
-	private List<InvalidValue> getInvalidValues(String IE) {
-		List<InvalidValue> errors = new ArrayList<InvalidValue>();
-		errors.clear();
-		if (IE != null) {
-			String unformatedIE = checkForCorrectFormat(IE, errors);
-			if (errors.isEmpty()) {
-				if (!hasValidCheckDigits(unformatedIE)) {
-					errors.add(IEError.INVALID_CHECK_DIGITS);
-				}
-			}
-		}
-		return errors;
-	}
+    private List<InvalidValue> getInvalidValues(String IE) {
+        List<InvalidValue> errors = new ArrayList<InvalidValue>();
+        errors.clear();
+        if (IE != null) {
+            String unformatedIE = checkForCorrectFormat(IE, errors);
+            if (errors.isEmpty()) {
+                if (!hasValidCheckDigits(unformatedIE)) {
+                    errors.add(IEError.INVALID_CHECK_DIGITS);
+                }
+            }
+        }
+        return errors;
+    }
 
-	protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
-		String unformatedIE = null;
-		if (isFormatted) {
-			if (!(FORMATED.matcher(ie).matches())) {
-				errors.add(IEError.INVALID_FORMAT);
-			}
-			unformatedIE = ie.replaceAll("\\D", "");
-		} else {
-			if (!UNFORMATED.matcher(ie).matches()) {
-				errors.add(IEError.INVALID_DIGITS);
-			}
-			unformatedIE = ie;
-		}
-		return unformatedIE;
-	}
+    protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
+        String unformatedIE = null;
+        if (isFormatted) {
+            if (!(FORMATED.matcher(ie).matches())) {
+                errors.add(IEError.INVALID_FORMAT);
+            }
+            unformatedIE = ie.replaceAll("\\D", "");
+        } else {
+            if (!UNFORMATED.matcher(ie).matches()) {
+                errors.add(IEError.INVALID_DIGITS);
+            }
+            unformatedIE = ie;
+        }
+        return unformatedIE;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	public boolean isEligible(String value) {
-		boolean result;
-		if (isFormatted) {
-			result = FORMATED.matcher(value).matches();
-		} else {
-			result = UNFORMATED.matcher(value).matches();
-		}
-		return result;
-	}
+    public boolean isEligible(String value) {
+        boolean result;
+        if (isFormatted) {
+            result = FORMATED.matcher(value).matches();
+        } else {
+            result = UNFORMATED.matcher(value).matches();
+        }
+        return result;
+    }
 
-	private final BaseValidator baseValidator;
+    private final BaseValidator baseValidator;
 
-	public void assertValid(String cpf) {
-		baseValidator.assertValid(getInvalidValues(cpf));
-	}
+    public void assertValid(String cpf) {
+        baseValidator.assertValid(getInvalidValues(cpf));
+    }
 
-	public List<ValidationMessage> invalidMessagesFor(String cpf) {
-		return baseValidator.generateValidationMessages(getInvalidValues(cpf));
-	}
+    public List<ValidationMessage> invalidMessagesFor(String cpf) {
+        return baseValidator.generateValidationMessages(getInvalidValues(cpf));
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String primeiroDigito = String.valueOf(new Random().nextInt(5));
-		final String ieSemDigito = primeiroDigito + new DigitoGenerator().generate(8);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "###/#######");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String primeiroDigito = String.valueOf(new Random().nextInt(5));
+        final String ieSemDigito = primeiroDigito + new DigitoGenerator().generate(8);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "###/#######");
+        }
+        return ieComDigito;
+    }
 
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
-
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoSulValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoSulValidator.java
@@ -16,121 +16,121 @@ import br.com.caelum.stella.validation.error.IEError;
 
 public class IERioGrandeDoSulValidator extends AbstractIEValidator {
 
-    private final boolean isFormatted;
+	private final boolean isFormatted;
 
-    public static final Pattern FORMATED = Pattern.compile("[0-4]\\d{2}\\/\\d{7}");
+	public static final Pattern FORMATED = Pattern.compile("[0-4]\\d{2}\\/\\d{7}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("([0-4]\\d{2})\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("([0-4]\\d{2})\\d{7}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IERioGrandeDoSulValidator() {
-        this(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IERioGrandeDoSulValidator() {
+		this(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IERioGrandeDoSulValidator(boolean isFormatted) {
-        this.baseValidator = new BaseValidator();
-        this.isFormatted = isFormatted;
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IERioGrandeDoSulValidator(boolean isFormatted) {
+		this.baseValidator = new BaseValidator();
+		this.isFormatted = isFormatted;
+	}
 
-    public IERioGrandeDoSulValidator(MessageProducer messageProducer, boolean isFormatted) {
-        this.baseValidator = new BaseValidator(messageProducer);
-        this.isFormatted = isFormatted;
-    }
+	public IERioGrandeDoSulValidator(MessageProducer messageProducer, boolean isFormatted) {
+		this.baseValidator = new BaseValidator(messageProducer);
+		this.isFormatted = isFormatted;
+	}
 
-    private List<InvalidValue> getInvalidValues(String IE) {
-        List<InvalidValue> errors = new ArrayList<InvalidValue>();
-        errors.clear();
-        if (IE != null) {
-            String unformatedIE = checkForCorrectFormat(IE, errors);
-            if (errors.isEmpty()) {
-                if (!hasValidCheckDigits(unformatedIE)) {
-                    errors.add(IEError.INVALID_CHECK_DIGITS);
-                }
-            }
-        }
-        return errors;
-    }
+	private List<InvalidValue> getInvalidValues(String IE) {
+		List<InvalidValue> errors = new ArrayList<InvalidValue>();
+		errors.clear();
+		if (IE != null) {
+			String unformatedIE = checkForCorrectFormat(IE, errors);
+			if (errors.isEmpty()) {
+				if (!hasValidCheckDigits(unformatedIE)) {
+					errors.add(IEError.INVALID_CHECK_DIGITS);
+				}
+			}
+		}
+		return errors;
+	}
 
-    protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
-        String unformatedIE = null;
-        if (isFormatted) {
-            if (!(FORMATED.matcher(ie).matches())) {
-                errors.add(IEError.INVALID_FORMAT);
-            }
-            unformatedIE = ie.replaceAll("\\D", "");
-        } else {
-            if (!UNFORMATED.matcher(ie).matches()) {
-                errors.add(IEError.INVALID_DIGITS);
-            }
-            unformatedIE = ie;
-        }
-        return unformatedIE;
-    }
+	protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
+		String unformatedIE = null;
+		if (isFormatted) {
+			if (!(FORMATED.matcher(ie).matches())) {
+				errors.add(IEError.INVALID_FORMAT);
+			}
+			unformatedIE = ie.replaceAll("\\D", "");
+		} else {
+			if (!UNFORMATED.matcher(ie).matches()) {
+				errors.add(IEError.INVALID_DIGITS);
+			}
+			unformatedIE = ie;
+		}
+		return unformatedIE;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    public boolean isEligible(String value) {
-        boolean result;
-        if (isFormatted) {
-            result = FORMATED.matcher(value).matches();
-        } else {
-            result = UNFORMATED.matcher(value).matches();
-        }
-        return result;
-    }
+	public boolean isEligible(String value) {
+		boolean result;
+		if (isFormatted) {
+			result = FORMATED.matcher(value).matches();
+		} else {
+			result = UNFORMATED.matcher(value).matches();
+		}
+		return result;
+	}
 
-    private final BaseValidator baseValidator;
+	private final BaseValidator baseValidator;
 
-    public void assertValid(String cpf) {
-        baseValidator.assertValid(getInvalidValues(cpf));
-    }
+	public void assertValid(String cpf) {
+		baseValidator.assertValid(getInvalidValues(cpf));
+	}
 
-    public List<ValidationMessage> invalidMessagesFor(String cpf) {
-        return baseValidator.generateValidationMessages(getInvalidValues(cpf));
-    }
+	public List<ValidationMessage> invalidMessagesFor(String cpf) {
+		return baseValidator.generateValidationMessages(getInvalidValues(cpf));
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String primeiroDigito = String.valueOf(new Random().nextInt(5));
-        final String ieSemDigito = primeiroDigito + new DigitoGenerator().generate(8);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "###/#######");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String primeiroDigito = String.valueOf(new Random().nextInt(5));
+		final String ieSemDigito = primeiroDigito + new DigitoGenerator().generate(8);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "###/#######");
+		}
+		return ieComDigito;
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERondoniaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERondoniaValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -12,12 +9,11 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IERondoniaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{13}-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{13}-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{14}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{14}");
 
-	
-    /**
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -40,7 +36,6 @@ public class IERondoniaValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -60,18 +55,8 @@ public class IERondoniaValidator extends AbstractIEValidator {
 	}
 
 	private String calculaDigito(String iESemDigito) {
-		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
-	}
-
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("#############-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
+		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10)
+				.trocandoPorSeEncontrar("1", 11).calcula();
 	}
 
 	@Override
@@ -79,7 +64,7 @@ public class IERondoniaValidator extends AbstractIEValidator {
 		final String ieSemDigito = new DigitoGenerator().generate(13);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "#############-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERondoniaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERondoniaValidator.java
@@ -9,63 +9,63 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IERondoniaValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("\\d{13}-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("\\d{13}-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("\\d{14}");
+    public static final Pattern UNFORMATED = Pattern.compile("\\d{14}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IERondoniaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IERondoniaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IERondoniaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IERondoniaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IERondoniaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IERondoniaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
-		String digitoCalculado = calculaDigito(iESemDigito);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10)
-				.trocandoPorSeEncontrar("1", 11).calcula();
-	}
+    private String calculaDigito(String iESemDigito) {
+        return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10)
+                .trocandoPorSeEncontrar("1", 11).calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = new DigitoGenerator().generate(13);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "#############-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = new DigitoGenerator().generate(13);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "#############-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERondoniaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERondoniaValidator.java
@@ -9,63 +9,63 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IERondoniaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{13}-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{13}-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{14}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{14}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IERondoniaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IERondoniaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IERondoniaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IERondoniaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IERondoniaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IERondoniaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
-        String digitoCalculado = calculaDigito(iESemDigito);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10)
-                .trocandoPorSeEncontrar("1", 11).calcula();
-    }
+	private String calculaDigito(String iESemDigito) {
+		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10)
+				.trocandoPorSeEncontrar("1", 11).calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = new DigitoGenerator().generate(13);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "#############-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = new DigitoGenerator().generate(13);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "#############-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERoraimaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERoraimaValidator.java
@@ -12,12 +12,11 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IERoraimaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("24\\d{6}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("24\\d{6}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
 
-
-    /**
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -59,18 +58,7 @@ public class IERoraimaValidator extends AbstractIEValidator {
 	}
 
 	private String calculaDigito(String iESemDigito) {
-		return new DigitoPara(iESemDigito).comMultiplicadores(8,7,6,5,4,3,2,1).mod(9).calcula();
-	}
-
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("########-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
+		return new DigitoPara(iESemDigito).comMultiplicadores(8, 7, 6, 5, 4, 3, 2, 1).mod(9).calcula();
 	}
 
 	@Override
@@ -78,7 +66,7 @@ public class IERoraimaValidator extends AbstractIEValidator {
 		final String ieSemDigito = "24" + new DigitoGenerator().generate(6);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "########-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERoraimaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERoraimaValidator.java
@@ -12,62 +12,62 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IERoraimaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("24\\d{6}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("24\\d{6}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IERoraimaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IERoraimaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IERoraimaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IERoraimaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IERoraimaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IERoraimaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
-        String digitoCalculado = calculaDigito(iESemDigito);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        return new DigitoPara(iESemDigito).comMultiplicadores(8, 7, 6, 5, 4, 3, 2, 1).mod(9).calcula();
-    }
+	private String calculaDigito(String iESemDigito) {
+		return new DigitoPara(iESemDigito).comMultiplicadores(8, 7, 6, 5, 4, 3, 2, 1).mod(9).calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = "24" + new DigitoGenerator().generate(6);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "########-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = "24" + new DigitoGenerator().generate(6);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "########-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERoraimaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERoraimaValidator.java
@@ -12,62 +12,62 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IERoraimaValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("24\\d{6}\\-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("24\\d{6}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
+    public static final Pattern UNFORMATED = Pattern.compile("24\\d{7}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IERoraimaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IERoraimaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IERoraimaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IERoraimaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IERoraimaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IERoraimaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
-		String digitoCalculado = calculaDigito(iESemDigito);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		return new DigitoPara(iESemDigito).comMultiplicadores(8, 7, 6, 5, 4, 3, 2, 1).mod(9).calcula();
-	}
+    private String calculaDigito(String iESemDigito) {
+        return new DigitoPara(iESemDigito).comMultiplicadores(8, 7, 6, 5, 4, 3, 2, 1).mod(9).calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = "24" + new DigitoGenerator().generate(6);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "########-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = "24" + new DigitoGenerator().generate(6);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "########-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESantaCatarinaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESantaCatarinaValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -12,11 +9,11 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IESantaCatarinaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{3}(\\.?\\d{3}){2}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{3}(\\.?\\d{3}){2}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-    /**
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -39,7 +36,6 @@ public class IESantaCatarinaValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -49,15 +45,15 @@ public class IESantaCatarinaValidator extends AbstractIEValidator {
 	protected Pattern getFormattedPattern() {
 		return FORMATED;
 	}
-	
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
 		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
 		DigitoPara digitoPara = new DigitoPara(iESemDigito);
@@ -66,23 +62,12 @@ public class IESantaCatarinaValidator extends AbstractIEValidator {
 		return digitoPara.calcula();
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("###.###.###");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = new DigitoGenerator().generate(8);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "###.###.###");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESantaCatarinaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESantaCatarinaValidator.java
@@ -9,66 +9,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IESantaCatarinaValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("\\d{3}(\\.?\\d{3}){2}");
+    public static final Pattern FORMATED = Pattern.compile("\\d{3}(\\.?\\d{3}){2}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IESantaCatarinaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IESantaCatarinaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IESantaCatarinaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IESantaCatarinaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IESantaCatarinaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IESantaCatarinaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = new DigitoGenerator().generate(8);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "###.###.###");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = new DigitoGenerator().generate(8);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "###.###.###");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESantaCatarinaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESantaCatarinaValidator.java
@@ -9,66 +9,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IESantaCatarinaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{3}(\\.?\\d{3}){2}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{3}(\\.?\\d{3}){2}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IESantaCatarinaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IESantaCatarinaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IESantaCatarinaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IESantaCatarinaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IESantaCatarinaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IESantaCatarinaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = new DigitoGenerator().generate(8);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "###.###.###");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = new DigitoGenerator().generate(8);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "###.###.###");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloComercioIndustriaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloComercioIndustriaValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -12,11 +9,11 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 class IESaoPauloComercioIndustriaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){3}\\d{3}");
+	public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){3}\\d{3}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{12}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{12}");
 
-    /**
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -39,7 +36,6 @@ class IESaoPauloComercioIndustriaValidator extends AbstractIEValidator {
 		super(messageProducer, isFormatted);
 	}
 
-
 	@Override
 	protected Pattern getUnformattedPattern() {
 		return UNFORMATED;
@@ -49,38 +45,27 @@ class IESaoPauloComercioIndustriaValidator extends AbstractIEValidator {
 	protected Pattern getFormattedPattern() {
 		return FORMATED;
 	}
-	
+
 	protected boolean hasValidCheckDigits(String unformattedIE) {
 		int length = unformattedIE.length();
 
 		String iESemDigitoParte1 = unformattedIE.substring(0, length - 4);
-		String iESemDigitoParte2 = unformattedIE.substring(length -3, length - 1);
+		String iESemDigitoParte2 = unformattedIE.substring(length - 3, length - 1);
 
-		String digitos = unformattedIE.substring(length - 4, length -3) + unformattedIE.substring(length -1);
+		String digitos = unformattedIE.substring(length - 4, length - 3) + unformattedIE.substring(length - 1);
 		String digitosCalculados = calculaDigitos(iESemDigitoParte1, iESemDigitoParte2);
 
 		return digitos.equals(digitosCalculados);
 	}
 
 	private String calculaDigitos(String iEParte1, String iEParte2) {
-		String digito1 = new DigitoPara(iEParte1).comMultiplicadores(10,8,7,6,5,4,3,1)
-					.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
+		String digito1 = new DigitoPara(iEParte1).comMultiplicadores(10, 8, 7, 6, 5, 4, 3, 1)
+				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
 
 		String digito2 = new DigitoPara(iEParte1 + digito1 + iEParte2).comMultiplicadoresDeAte(2, 10)
-					.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
+				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
 
 		return digito1 + digito2;
-	}
-
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("###.###.###.###");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
 	}
 
 	@Override
@@ -89,10 +74,10 @@ class IESaoPauloComercioIndustriaValidator extends AbstractIEValidator {
 		final String ieSemDigitosParte1 = digitoGenerator.generate(8);
 		final String ieSemDigitosParte2 = digitoGenerator.generate(2);
 		final String digitosCalculados = calculaDigitos(ieSemDigitosParte1, ieSemDigitosParte2);
-		final String ieComDigitos = ieSemDigitosParte1 + digitosCalculados.charAt(0)
-		        + ieSemDigitosParte2 + digitosCalculados.charAt(1);
+		final String ieComDigitos = ieSemDigitosParte1 + digitosCalculados.charAt(0) + ieSemDigitosParte2
+				+ digitosCalculados.charAt(1);
 		if (isFormatted) {
-			return formata(ieComDigitos);
+			return super.format(ieComDigitos, "###.###.###.###");
 		}
 		return ieComDigitos;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloComercioIndustriaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloComercioIndustriaValidator.java
@@ -9,76 +9,76 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 class IESaoPauloComercioIndustriaValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){3}\\d{3}");
+	public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){3}\\d{3}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{12}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{12}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IESaoPauloComercioIndustriaValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IESaoPauloComercioIndustriaValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IESaoPauloComercioIndustriaValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IESaoPauloComercioIndustriaValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IESaoPauloComercioIndustriaValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IESaoPauloComercioIndustriaValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        int length = unformattedIE.length();
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		int length = unformattedIE.length();
 
-        String iESemDigitoParte1 = unformattedIE.substring(0, length - 4);
-        String iESemDigitoParte2 = unformattedIE.substring(length - 3, length - 1);
+		String iESemDigitoParte1 = unformattedIE.substring(0, length - 4);
+		String iESemDigitoParte2 = unformattedIE.substring(length - 3, length - 1);
 
-        String digitos = unformattedIE.substring(length - 4, length - 3) + unformattedIE.substring(length - 1);
-        String digitosCalculados = calculaDigitos(iESemDigitoParte1, iESemDigitoParte2);
+		String digitos = unformattedIE.substring(length - 4, length - 3) + unformattedIE.substring(length - 1);
+		String digitosCalculados = calculaDigitos(iESemDigitoParte1, iESemDigitoParte2);
 
-        return digitos.equals(digitosCalculados);
-    }
+		return digitos.equals(digitosCalculados);
+	}
 
-    private String calculaDigitos(String iEParte1, String iEParte2) {
-        String digito1 = new DigitoPara(iEParte1).comMultiplicadores(10, 8, 7, 6, 5, 4, 3, 1)
-                .trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
+	private String calculaDigitos(String iEParte1, String iEParte2) {
+		String digito1 = new DigitoPara(iEParte1).comMultiplicadores(10, 8, 7, 6, 5, 4, 3, 1)
+				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
 
-        String digito2 = new DigitoPara(iEParte1 + digito1 + iEParte2).comMultiplicadoresDeAte(2, 10)
-                .trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
+		String digito2 = new DigitoPara(iEParte1 + digito1 + iEParte2).comMultiplicadoresDeAte(2, 10)
+				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
 
-        return digito1 + digito2;
-    }
+		return digito1 + digito2;
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final DigitoGenerator digitoGenerator = new DigitoGenerator();
-        final String ieSemDigitosParte1 = digitoGenerator.generate(8);
-        final String ieSemDigitosParte2 = digitoGenerator.generate(2);
-        final String digitosCalculados = calculaDigitos(ieSemDigitosParte1, ieSemDigitosParte2);
-        final String ieComDigitos = ieSemDigitosParte1 + digitosCalculados.charAt(0) + ieSemDigitosParte2
-                + digitosCalculados.charAt(1);
-        if (isFormatted) {
-            return super.format(ieComDigitos, "###.###.###.###");
-        }
-        return ieComDigitos;
-    }
+	@Override
+	public String generateRandomValid() {
+		final DigitoGenerator digitoGenerator = new DigitoGenerator();
+		final String ieSemDigitosParte1 = digitoGenerator.generate(8);
+		final String ieSemDigitosParte2 = digitoGenerator.generate(2);
+		final String digitosCalculados = calculaDigitos(ieSemDigitosParte1, ieSemDigitosParte2);
+		final String ieComDigitos = ieSemDigitosParte1 + digitosCalculados.charAt(0) + ieSemDigitosParte2
+				+ digitosCalculados.charAt(1);
+		if (isFormatted) {
+			return super.format(ieComDigitos, "###.###.###.###");
+		}
+		return ieComDigitos;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloComercioIndustriaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloComercioIndustriaValidator.java
@@ -9,76 +9,76 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 class IESaoPauloComercioIndustriaValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){3}\\d{3}");
+    public static final Pattern FORMATED = Pattern.compile("(\\d{3}\\.){3}\\d{3}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("\\d{12}");
+    public static final Pattern UNFORMATED = Pattern.compile("\\d{12}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IESaoPauloComercioIndustriaValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IESaoPauloComercioIndustriaValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IESaoPauloComercioIndustriaValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IESaoPauloComercioIndustriaValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IESaoPauloComercioIndustriaValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IESaoPauloComercioIndustriaValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		int length = unformattedIE.length();
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        int length = unformattedIE.length();
 
-		String iESemDigitoParte1 = unformattedIE.substring(0, length - 4);
-		String iESemDigitoParte2 = unformattedIE.substring(length - 3, length - 1);
+        String iESemDigitoParte1 = unformattedIE.substring(0, length - 4);
+        String iESemDigitoParte2 = unformattedIE.substring(length - 3, length - 1);
 
-		String digitos = unformattedIE.substring(length - 4, length - 3) + unformattedIE.substring(length - 1);
-		String digitosCalculados = calculaDigitos(iESemDigitoParte1, iESemDigitoParte2);
+        String digitos = unformattedIE.substring(length - 4, length - 3) + unformattedIE.substring(length - 1);
+        String digitosCalculados = calculaDigitos(iESemDigitoParte1, iESemDigitoParte2);
 
-		return digitos.equals(digitosCalculados);
-	}
+        return digitos.equals(digitosCalculados);
+    }
 
-	private String calculaDigitos(String iEParte1, String iEParte2) {
-		String digito1 = new DigitoPara(iEParte1).comMultiplicadores(10, 8, 7, 6, 5, 4, 3, 1)
-				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
+    private String calculaDigitos(String iEParte1, String iEParte2) {
+        String digito1 = new DigitoPara(iEParte1).comMultiplicadores(10, 8, 7, 6, 5, 4, 3, 1)
+                .trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
 
-		String digito2 = new DigitoPara(iEParte1 + digito1 + iEParte2).comMultiplicadoresDeAte(2, 10)
-				.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
+        String digito2 = new DigitoPara(iEParte1 + digito1 + iEParte2).comMultiplicadoresDeAte(2, 10)
+                .trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
 
-		return digito1 + digito2;
-	}
+        return digito1 + digito2;
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final DigitoGenerator digitoGenerator = new DigitoGenerator();
-		final String ieSemDigitosParte1 = digitoGenerator.generate(8);
-		final String ieSemDigitosParte2 = digitoGenerator.generate(2);
-		final String digitosCalculados = calculaDigitos(ieSemDigitosParte1, ieSemDigitosParte2);
-		final String ieComDigitos = ieSemDigitosParte1 + digitosCalculados.charAt(0) + ieSemDigitosParte2
-				+ digitosCalculados.charAt(1);
-		if (isFormatted) {
-			return super.format(ieComDigitos, "###.###.###.###");
-		}
-		return ieComDigitos;
-	}
+    @Override
+    public String generateRandomValid() {
+        final DigitoGenerator digitoGenerator = new DigitoGenerator();
+        final String ieSemDigitosParte1 = digitoGenerator.generate(8);
+        final String ieSemDigitosParte2 = digitoGenerator.generate(2);
+        final String digitosCalculados = calculaDigitos(ieSemDigitosParte1, ieSemDigitosParte2);
+        final String ieComDigitos = ieSemDigitosParte1 + digitosCalculados.charAt(0) + ieSemDigitosParte2
+                + digitosCalculados.charAt(1);
+        if (isFormatted) {
+            return super.format(ieComDigitos, "###.###.###.###");
+        }
+        return ieComDigitos;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloProdutorRuralValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloProdutorRuralValidator.java
@@ -1,11 +1,8 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -13,107 +10,104 @@ import br.com.caelum.stella.MessageProducer;
 import br.com.caelum.stella.ValidationMessage;
 import br.com.caelum.stella.validation.BaseValidator;
 import br.com.caelum.stella.validation.InvalidValue;
-import br.com.caelum.stella.validation.Validator;
 import br.com.caelum.stella.validation.error.IEError;
 
-class IESaoPauloProdutorRuralValidator implements Validator<String> {
+class IESaoPauloProdutorRuralValidator extends AbstractIEValidator {
 
-    private final boolean isFormatted;
+	private final boolean isFormatted;
 
-    public static final Pattern FORMATED = Pattern.compile("P-\\d{8}\\.\\d{1}/\\d{3}");
+	public static final Pattern FORMATED = Pattern.compile("P-\\d{8}\\.\\d{1}/\\d{3}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("P\\d{12}");
+	public static final Pattern UNFORMATED = Pattern.compile("P\\d{12}");
 
-    public IESaoPauloProdutorRuralValidator(MessageProducer messageProducer, boolean isFormatted) {
-        this.baseValidator = new BaseValidator(messageProducer);
-        this.isFormatted = isFormatted;
-    }
+	public IESaoPauloProdutorRuralValidator(MessageProducer messageProducer, boolean isFormatted) {
+		this.baseValidator = new BaseValidator(messageProducer);
+		this.isFormatted = isFormatted;
+	}
 
-    private List<InvalidValue> getInvalidValues(String ie) {
-        List<InvalidValue> errors = new ArrayList<InvalidValue>();
-        errors.clear();
-        if (ie != null) {
-            String unformatedIE = checkForCorrectFormat(ie, errors);
-            if (errors.isEmpty()) {
-                if (!hasValidCheckDigits(unformatedIE)) {
-                    errors.add(IEError.INVALID_CHECK_DIGITS);
-                }
-            }
-        }
-        return errors;
-    }
+	private List<InvalidValue> getInvalidValues(String ie) {
+		List<InvalidValue> errors = new ArrayList<InvalidValue>();
+		errors.clear();
+		if (ie != null) {
+			String unformatedIE = checkForCorrectFormat(ie, errors);
+			if (errors.isEmpty()) {
+				if (!hasValidCheckDigits(unformatedIE)) {
+					errors.add(IEError.INVALID_CHECK_DIGITS);
+				}
+			}
+		}
+		return errors;
+	}
 
-    private String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
-        String unformatedIE = null;
-        if (isFormatted) {
-            if (!(FORMATED.matcher(ie).matches())) {
-                errors.add(IEError.INVALID_FORMAT);
-            }
-            unformatedIE = ie.replaceAll("\\D", "");
-        } else {
-            if (!UNFORMATED.matcher(ie).matches()) {
-                errors.add(IEError.INVALID_DIGITS);
-            }
-            unformatedIE = ie.replaceAll("\\D", "");
-        }
-        return unformatedIE;
-    }
+	protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
+		String unformatedIE = null;
+		if (isFormatted) {
+			if (!(FORMATED.matcher(ie).matches())) {
+				errors.add(IEError.INVALID_FORMAT);
+			}
+			unformatedIE = ie.replaceAll("\\D", "");
+		} else {
+			if (!UNFORMATED.matcher(ie).matches()) {
+				errors.add(IEError.INVALID_DIGITS);
+			}
+			unformatedIE = ie.replaceAll("\\D", "");
+		}
+		return unformatedIE;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
+	protected boolean hasValidCheckDigits(String unformattedIE) {
 		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 4);
 		String digito = unformattedIE.substring(unformattedIE.length() - 4, unformattedIE.length() - 3);
 
 		String digitoCalculado = calculaDigito(iESemDigito);
 
 		return digito.equals(digitoCalculado);
-    }
+	}
 
 	private String calculaDigito(String iESemDigito) {
-		return new DigitoPara(iESemDigito).comMultiplicadores(10,8,7,6,5,4,3,1)
-						.trocandoPorSeEncontrar("0", 10).trocandoPorSeEncontrar("1", 11).calcula();
+		return new DigitoPara(iESemDigito).comMultiplicadores(10, 8, 7, 6, 5, 4, 3, 1).trocandoPorSeEncontrar("0", 10)
+				.trocandoPorSeEncontrar("1", 11).calcula();
 	}
 
-    public boolean isEligible(String value) {
-        boolean result;
-        if (isFormatted) {
-            result = FORMATED.matcher(value).matches();
-        } else {
-            result = UNFORMATED.matcher(value).matches();
-        }
-        return result;
-    }
-
-    private final BaseValidator baseValidator;
-
-    public void assertValid(String cpf) {
-        baseValidator.assertValid(getInvalidValues(cpf));
-    }
-
-    public List<ValidationMessage> invalidMessagesFor(String cpf) {
-        return baseValidator.generateValidationMessages(getInvalidValues(cpf));
-    }
-
-    private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("U-########.#/###");
-			formatador.setValidCharacters("P1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
+	public boolean isEligible(String value) {
+		boolean result;
+		if (isFormatted) {
+			result = FORMATED.matcher(value).matches();
+		} else {
+			result = UNFORMATED.matcher(value).matches();
 		}
+		return result;
 	}
-    
+
+	private final BaseValidator baseValidator;
+
+	public void assertValid(String cpf) {
+		baseValidator.assertValid(getInvalidValues(cpf));
+	}
+
+	public List<ValidationMessage> invalidMessagesFor(String cpf) {
+		return baseValidator.generateValidationMessages(getInvalidValues(cpf));
+	}
+
 	@Override
 	public String generateRandomValid() {
 		final DigitoGenerator digitoGenerator = new DigitoGenerator();
 		final String ieSemDigitoParte1 = digitoGenerator.generate(8);
 		final String ieSemDigitoParte2 = digitoGenerator.generate(3);
-		final String ieComDigito = "P" + ieSemDigitoParte1 + calculaDigito(ieSemDigitoParte1)
-		        + ieSemDigitoParte2;
+		final String ieComDigito = "P" + ieSemDigitoParte1 + calculaDigito(ieSemDigitoParte1) + ieSemDigitoParte2;
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "U-########.#/###", "P1234567890");
 		}
 		return ieComDigito;
+	}
+
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
+
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
 	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloProdutorRuralValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloProdutorRuralValidator.java
@@ -14,100 +14,100 @@ import br.com.caelum.stella.validation.error.IEError;
 
 class IESaoPauloProdutorRuralValidator extends AbstractIEValidator {
 
-	private final boolean isFormatted;
+    private final boolean isFormatted;
 
-	public static final Pattern FORMATED = Pattern.compile("P-\\d{8}\\.\\d{1}/\\d{3}");
+    public static final Pattern FORMATED = Pattern.compile("P-\\d{8}\\.\\d{1}/\\d{3}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("P\\d{12}");
+    public static final Pattern UNFORMATED = Pattern.compile("P\\d{12}");
 
-	public IESaoPauloProdutorRuralValidator(MessageProducer messageProducer, boolean isFormatted) {
-		this.baseValidator = new BaseValidator(messageProducer);
-		this.isFormatted = isFormatted;
-	}
+    public IESaoPauloProdutorRuralValidator(MessageProducer messageProducer, boolean isFormatted) {
+        this.baseValidator = new BaseValidator(messageProducer);
+        this.isFormatted = isFormatted;
+    }
 
-	private List<InvalidValue> getInvalidValues(String ie) {
-		List<InvalidValue> errors = new ArrayList<InvalidValue>();
-		errors.clear();
-		if (ie != null) {
-			String unformatedIE = checkForCorrectFormat(ie, errors);
-			if (errors.isEmpty()) {
-				if (!hasValidCheckDigits(unformatedIE)) {
-					errors.add(IEError.INVALID_CHECK_DIGITS);
-				}
-			}
-		}
-		return errors;
-	}
+    private List<InvalidValue> getInvalidValues(String ie) {
+        List<InvalidValue> errors = new ArrayList<InvalidValue>();
+        errors.clear();
+        if (ie != null) {
+            String unformatedIE = checkForCorrectFormat(ie, errors);
+            if (errors.isEmpty()) {
+                if (!hasValidCheckDigits(unformatedIE)) {
+                    errors.add(IEError.INVALID_CHECK_DIGITS);
+                }
+            }
+        }
+        return errors;
+    }
 
-	protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
-		String unformatedIE = null;
-		if (isFormatted) {
-			if (!(FORMATED.matcher(ie).matches())) {
-				errors.add(IEError.INVALID_FORMAT);
-			}
-			unformatedIE = ie.replaceAll("\\D", "");
-		} else {
-			if (!UNFORMATED.matcher(ie).matches()) {
-				errors.add(IEError.INVALID_DIGITS);
-			}
-			unformatedIE = ie.replaceAll("\\D", "");
-		}
-		return unformatedIE;
-	}
+    protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
+        String unformatedIE = null;
+        if (isFormatted) {
+            if (!(FORMATED.matcher(ie).matches())) {
+                errors.add(IEError.INVALID_FORMAT);
+            }
+            unformatedIE = ie.replaceAll("\\D", "");
+        } else {
+            if (!UNFORMATED.matcher(ie).matches()) {
+                errors.add(IEError.INVALID_DIGITS);
+            }
+            unformatedIE = ie.replaceAll("\\D", "");
+        }
+        return unformatedIE;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 4);
-		String digito = unformattedIE.substring(unformattedIE.length() - 4, unformattedIE.length() - 3);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 4);
+        String digito = unformattedIE.substring(unformattedIE.length() - 4, unformattedIE.length() - 3);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		return new DigitoPara(iESemDigito).comMultiplicadores(10, 8, 7, 6, 5, 4, 3, 1).trocandoPorSeEncontrar("0", 10)
-				.trocandoPorSeEncontrar("1", 11).calcula();
-	}
+    private String calculaDigito(String iESemDigito) {
+        return new DigitoPara(iESemDigito).comMultiplicadores(10, 8, 7, 6, 5, 4, 3, 1).trocandoPorSeEncontrar("0", 10)
+                .trocandoPorSeEncontrar("1", 11).calcula();
+    }
 
-	public boolean isEligible(String value) {
-		boolean result;
-		if (isFormatted) {
-			result = FORMATED.matcher(value).matches();
-		} else {
-			result = UNFORMATED.matcher(value).matches();
-		}
-		return result;
-	}
+    public boolean isEligible(String value) {
+        boolean result;
+        if (isFormatted) {
+            result = FORMATED.matcher(value).matches();
+        } else {
+            result = UNFORMATED.matcher(value).matches();
+        }
+        return result;
+    }
 
-	private final BaseValidator baseValidator;
+    private final BaseValidator baseValidator;
 
-	public void assertValid(String cpf) {
-		baseValidator.assertValid(getInvalidValues(cpf));
-	}
+    public void assertValid(String cpf) {
+        baseValidator.assertValid(getInvalidValues(cpf));
+    }
 
-	public List<ValidationMessage> invalidMessagesFor(String cpf) {
-		return baseValidator.generateValidationMessages(getInvalidValues(cpf));
-	}
+    public List<ValidationMessage> invalidMessagesFor(String cpf) {
+        return baseValidator.generateValidationMessages(getInvalidValues(cpf));
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final DigitoGenerator digitoGenerator = new DigitoGenerator();
-		final String ieSemDigitoParte1 = digitoGenerator.generate(8);
-		final String ieSemDigitoParte2 = digitoGenerator.generate(3);
-		final String ieComDigito = "P" + ieSemDigitoParte1 + calculaDigito(ieSemDigitoParte1) + ieSemDigitoParte2;
-		if (isFormatted) {
-			return super.format(ieComDigito, "U-########.#/###", "P1234567890");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final DigitoGenerator digitoGenerator = new DigitoGenerator();
+        final String ieSemDigitoParte1 = digitoGenerator.generate(8);
+        final String ieSemDigitoParte2 = digitoGenerator.generate(3);
+        final String ieComDigito = "P" + ieSemDigitoParte1 + calculaDigito(ieSemDigitoParte1) + ieSemDigitoParte2;
+        if (isFormatted) {
+            return super.format(ieComDigito, "U-########.#/###", "P1234567890");
+        }
+        return ieComDigito;
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloProdutorRuralValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloProdutorRuralValidator.java
@@ -14,100 +14,100 @@ import br.com.caelum.stella.validation.error.IEError;
 
 class IESaoPauloProdutorRuralValidator extends AbstractIEValidator {
 
-    private final boolean isFormatted;
+	private final boolean isFormatted;
 
-    public static final Pattern FORMATED = Pattern.compile("P-\\d{8}\\.\\d{1}/\\d{3}");
+	public static final Pattern FORMATED = Pattern.compile("P-\\d{8}\\.\\d{1}/\\d{3}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("P\\d{12}");
+	public static final Pattern UNFORMATED = Pattern.compile("P\\d{12}");
 
-    public IESaoPauloProdutorRuralValidator(MessageProducer messageProducer, boolean isFormatted) {
-        this.baseValidator = new BaseValidator(messageProducer);
-        this.isFormatted = isFormatted;
-    }
+	public IESaoPauloProdutorRuralValidator(MessageProducer messageProducer, boolean isFormatted) {
+		this.baseValidator = new BaseValidator(messageProducer);
+		this.isFormatted = isFormatted;
+	}
 
-    private List<InvalidValue> getInvalidValues(String ie) {
-        List<InvalidValue> errors = new ArrayList<InvalidValue>();
-        errors.clear();
-        if (ie != null) {
-            String unformatedIE = checkForCorrectFormat(ie, errors);
-            if (errors.isEmpty()) {
-                if (!hasValidCheckDigits(unformatedIE)) {
-                    errors.add(IEError.INVALID_CHECK_DIGITS);
-                }
-            }
-        }
-        return errors;
-    }
+	private List<InvalidValue> getInvalidValues(String ie) {
+		List<InvalidValue> errors = new ArrayList<InvalidValue>();
+		errors.clear();
+		if (ie != null) {
+			String unformatedIE = checkForCorrectFormat(ie, errors);
+			if (errors.isEmpty()) {
+				if (!hasValidCheckDigits(unformatedIE)) {
+					errors.add(IEError.INVALID_CHECK_DIGITS);
+				}
+			}
+		}
+		return errors;
+	}
 
-    protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
-        String unformatedIE = null;
-        if (isFormatted) {
-            if (!(FORMATED.matcher(ie).matches())) {
-                errors.add(IEError.INVALID_FORMAT);
-            }
-            unformatedIE = ie.replaceAll("\\D", "");
-        } else {
-            if (!UNFORMATED.matcher(ie).matches()) {
-                errors.add(IEError.INVALID_DIGITS);
-            }
-            unformatedIE = ie.replaceAll("\\D", "");
-        }
-        return unformatedIE;
-    }
+	protected String checkForCorrectFormat(String ie, List<InvalidValue> errors) {
+		String unformatedIE = null;
+		if (isFormatted) {
+			if (!(FORMATED.matcher(ie).matches())) {
+				errors.add(IEError.INVALID_FORMAT);
+			}
+			unformatedIE = ie.replaceAll("\\D", "");
+		} else {
+			if (!UNFORMATED.matcher(ie).matches()) {
+				errors.add(IEError.INVALID_DIGITS);
+			}
+			unformatedIE = ie.replaceAll("\\D", "");
+		}
+		return unformatedIE;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 4);
-        String digito = unformattedIE.substring(unformattedIE.length() - 4, unformattedIE.length() - 3);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 4);
+		String digito = unformattedIE.substring(unformattedIE.length() - 4, unformattedIE.length() - 3);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        return new DigitoPara(iESemDigito).comMultiplicadores(10, 8, 7, 6, 5, 4, 3, 1).trocandoPorSeEncontrar("0", 10)
-                .trocandoPorSeEncontrar("1", 11).calcula();
-    }
+	private String calculaDigito(String iESemDigito) {
+		return new DigitoPara(iESemDigito).comMultiplicadores(10, 8, 7, 6, 5, 4, 3, 1).trocandoPorSeEncontrar("0", 10)
+				.trocandoPorSeEncontrar("1", 11).calcula();
+	}
 
-    public boolean isEligible(String value) {
-        boolean result;
-        if (isFormatted) {
-            result = FORMATED.matcher(value).matches();
-        } else {
-            result = UNFORMATED.matcher(value).matches();
-        }
-        return result;
-    }
+	public boolean isEligible(String value) {
+		boolean result;
+		if (isFormatted) {
+			result = FORMATED.matcher(value).matches();
+		} else {
+			result = UNFORMATED.matcher(value).matches();
+		}
+		return result;
+	}
 
-    private final BaseValidator baseValidator;
+	private final BaseValidator baseValidator;
 
-    public void assertValid(String cpf) {
-        baseValidator.assertValid(getInvalidValues(cpf));
-    }
+	public void assertValid(String cpf) {
+		baseValidator.assertValid(getInvalidValues(cpf));
+	}
 
-    public List<ValidationMessage> invalidMessagesFor(String cpf) {
-        return baseValidator.generateValidationMessages(getInvalidValues(cpf));
-    }
+	public List<ValidationMessage> invalidMessagesFor(String cpf) {
+		return baseValidator.generateValidationMessages(getInvalidValues(cpf));
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final DigitoGenerator digitoGenerator = new DigitoGenerator();
-        final String ieSemDigitoParte1 = digitoGenerator.generate(8);
-        final String ieSemDigitoParte2 = digitoGenerator.generate(3);
-        final String ieComDigito = "P" + ieSemDigitoParte1 + calculaDigito(ieSemDigitoParte1) + ieSemDigitoParte2;
-        if (isFormatted) {
-            return super.format(ieComDigito, "U-########.#/###", "P1234567890");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final DigitoGenerator digitoGenerator = new DigitoGenerator();
+		final String ieSemDigitoParte1 = digitoGenerator.generate(8);
+		final String ieSemDigitoParte2 = digitoGenerator.generate(3);
+		final String ieComDigito = "P" + ieSemDigitoParte1 + calculaDigito(ieSemDigitoParte1) + ieSemDigitoParte2;
+		if (isFormatted) {
+			return super.format(ieComDigito, "U-########.#/###", "P1234567890");
+		}
+		return ieComDigito;
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloValidator.java
@@ -35,7 +35,8 @@ public class IESaoPauloValidator implements Validator<String> {
 
     @SuppressWarnings("unchecked")
     public IESaoPauloValidator(MessageProducer messageProducer, boolean isFormatted) {
-        Class[] validatorClasses = { IESaoPauloComercioIndustriaValidator.class, IESaoPauloProdutorRuralValidator.class };
+        Class[] validatorClasses = { IESaoPauloComercioIndustriaValidator.class,
+                IESaoPauloProdutorRuralValidator.class };
         this.baseValidator = new LogicOrComposedValidator<String>(messageProducer, isFormatted, validatorClasses);
         this.baseValidator.setInvalidFormat(IEError.INVALID_FORMAT);
     }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESaoPauloValidator.java
@@ -12,62 +12,62 @@ import br.com.caelum.stella.validation.error.IEError;
 
 public class IESaoPauloValidator implements Validator<String> {
 
-    private final LogicOrComposedValidator<String> baseValidator;
+	private final LogicOrComposedValidator<String> baseValidator;
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IESaoPauloValidator() {
-        this(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IESaoPauloValidator() {
+		this(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IESaoPauloValidator(boolean isFormatted) {
-        this(new SimpleMessageProducer(), isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IESaoPauloValidator(boolean isFormatted) {
+		this(new SimpleMessageProducer(), isFormatted);
+	}
 
-    @SuppressWarnings("unchecked")
-    public IESaoPauloValidator(MessageProducer messageProducer, boolean isFormatted) {
-        Class[] validatorClasses = { IESaoPauloComercioIndustriaValidator.class,
-                IESaoPauloProdutorRuralValidator.class };
-        this.baseValidator = new LogicOrComposedValidator<String>(messageProducer, isFormatted, validatorClasses);
-        this.baseValidator.setInvalidFormat(IEError.INVALID_FORMAT);
-    }
+	@SuppressWarnings("unchecked")
+	public IESaoPauloValidator(MessageProducer messageProducer, boolean isFormatted) {
+		Class[] validatorClasses = { IESaoPauloComercioIndustriaValidator.class,
+				IESaoPauloProdutorRuralValidator.class };
+		this.baseValidator = new LogicOrComposedValidator<String>(messageProducer, isFormatted, validatorClasses);
+		this.baseValidator.setInvalidFormat(IEError.INVALID_FORMAT);
+	}
 
-    public void assertValid(String value) {
-        if (value != null) {
-            baseValidator.assertValid(value);
-        }
-    }
+	public void assertValid(String value) {
+		if (value != null) {
+			baseValidator.assertValid(value);
+		}
+	}
 
-    public List<ValidationMessage> invalidMessagesFor(String value) {
-        List<ValidationMessage> result;
-        if (value != null) {
-            result = baseValidator.invalidMessagesFor(value);
-        } else {
-            result = new ArrayList<ValidationMessage>();
-        }
-        return result;
-    }
+	public List<ValidationMessage> invalidMessagesFor(String value) {
+		List<ValidationMessage> result;
+		if (value != null) {
+			result = baseValidator.invalidMessagesFor(value);
+		} else {
+			result = new ArrayList<ValidationMessage>();
+		}
+		return result;
+	}
 
-    public boolean isEligible(String object) {
-        return baseValidator.isEligible(object);
-    }
+	public boolean isEligible(String object) {
+		return baseValidator.isEligible(object);
+	}
 
-    /**
-     * @see Validator#generateRandomValid()
-     * @see LogicOrComposedValidator#generateRandomValid()
-     * @return uma inscrição estadual de comércio e indústria válida
-     */
-    @Override
-    public String generateRandomValid() {
-        return baseValidator.generateRandomValid();
-    }
+	/**
+	 * @see Validator#generateRandomValid()
+	 * @see LogicOrComposedValidator#generateRandomValid()
+	 * @return uma inscrição estadual de comércio e indústria válida
+	 */
+	@Override
+	public String generateRandomValid() {
+		return baseValidator.generateRandomValid();
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESergipeValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESergipeValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -12,11 +9,11 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IESergipeValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.?\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.?\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-    /**
+	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
 	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
 	 */
@@ -38,7 +35,6 @@ public class IESergipeValidator extends AbstractIEValidator {
 	public IESergipeValidator(MessageProducer messageProducer, boolean isFormatted) {
 		super(messageProducer, isFormatted);
 	}
-
 
 	@Override
 	protected Pattern getUnformattedPattern() {
@@ -66,23 +62,12 @@ public class IESergipeValidator extends AbstractIEValidator {
 		return digitoPara.calcula();
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	@Override
 	public String generateRandomValid() {
 		final String ieSemDigito = new DigitoGenerator().generate(8);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return super.format(ieComDigito, "##.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESergipeValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESergipeValidator.java
@@ -9,66 +9,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IESergipeValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.?\\d{3}){2}\\-\\d{1}");
+    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.?\\d{3}){2}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-	/**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IESergipeValidator() {
-		super(true);
-	}
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IESergipeValidator() {
+        super(true);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IESergipeValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    /**
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IESergipeValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	public IESergipeValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    public IESergipeValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-		String digitoCalculado = calculaDigito(iESemDigito);
+        String digitoCalculado = calculaDigito(iESemDigito);
 
-		return digito.equals(digitoCalculado);
-	}
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		DigitoPara digitoPara = new DigitoPara(iESemDigito);
-		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+    private String calculaDigito(String iESemDigito) {
+        DigitoPara digitoPara = new DigitoPara(iESemDigito);
+        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-		return digitoPara.calcula();
-	}
+        return digitoPara.calcula();
+    }
 
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = new DigitoGenerator().generate(8);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###-#");
-		}
-		return ieComDigito;
-	}
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = new DigitoGenerator().generate(8);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return super.format(ieComDigito, "##.###.###-#");
+        }
+        return ieComDigito;
+    }
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESergipeValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IESergipeValidator.java
@@ -9,66 +9,66 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IESergipeValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.?\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.?\\d{3}){2}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
+	public static final Pattern UNFORMATED = Pattern.compile("\\d{9}");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IESergipeValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IESergipeValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IESergipeValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IESergipeValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IESergipeValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IESergipeValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        String digitoCalculado = calculaDigito(iESemDigito);
+		String digitoCalculado = calculaDigito(iESemDigito);
 
-        return digito.equals(digitoCalculado);
-    }
+		return digito.equals(digitoCalculado);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        DigitoPara digitoPara = new DigitoPara(iESemDigito);
-        digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
+	private String calculaDigito(String iESemDigito) {
+		DigitoPara digitoPara = new DigitoPara(iESemDigito);
+		digitoPara.complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11);
 
-        return digitoPara.calcula();
-    }
+		return digitoPara.calcula();
+	}
 
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = new DigitoGenerator().generate(8);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return super.format(ieComDigito, "##.###.###-#");
-        }
-        return ieComDigito;
-    }
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = new DigitoGenerator().generate(8);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return super.format(ieComDigito, "##.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IETocantinsValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IETocantinsValidator.java
@@ -23,74 +23,74 @@ import br.com.caelum.stella.validation.Validator;
  */
 public class IETocantinsValidator extends AbstractIEValidator {
 
-    public static final Pattern FORMATED = Pattern.compile("\\d{2}(.\\d{2}.)?(\\.)?\\d{3}\\.\\d{3}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}(.\\d{2}.)?(\\.)?\\d{3}\\.\\d{3}\\-\\d{1}");
 
-    public static final Pattern UNFORMATED = Pattern.compile("(\\d{9}|\\d{11})");
+	public static final Pattern UNFORMATED = Pattern.compile("(\\d{9}|\\d{11})");
 
-    /**
-     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-     * {@linkplain SimpleMessageProducer} para geração de mensagens.
-     */
-    public IETocantinsValidator() {
-        super(true);
-    }
+	/**
+	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
+	 */
+	public IETocantinsValidator() {
+		super(true);
+	}
 
-    /**
-     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-     * mensagens.
-     * 
-     * @param isFormatted
-     *            considerar cadeia formatada quando <code>true</code>
-     */
-    public IETocantinsValidator(boolean isFormatted) {
-        super(isFormatted);
-    }
+	/**
+	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+	 * mensagens.
+	 * 
+	 * @param isFormatted
+	 *            considerar cadeia formatada quando <code>true</code>
+	 */
+	public IETocantinsValidator(boolean isFormatted) {
+		super(isFormatted);
+	}
 
-    public IETocantinsValidator(MessageProducer messageProducer, boolean isFormatted) {
-        super(messageProducer, isFormatted);
-    }
+	public IETocantinsValidator(MessageProducer messageProducer, boolean isFormatted) {
+		super(messageProducer, isFormatted);
+	}
 
-    @Override
-    protected Pattern getUnformattedPattern() {
-        return UNFORMATED;
-    }
+	@Override
+	protected Pattern getUnformattedPattern() {
+		return UNFORMATED;
+	}
 
-    @Override
-    protected Pattern getFormattedPattern() {
-        return FORMATED;
-    }
+	@Override
+	protected Pattern getFormattedPattern() {
+		return FORMATED;
+	}
 
-    protected boolean hasValidCheckDigits(String unformattedIE) {
-        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-        String digito = unformattedIE.substring(unformattedIE.length() - 1);
+	protected boolean hasValidCheckDigits(String unformattedIE) {
+		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+		String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-        if (iESemDigito.length() == 10) {
-            iESemDigito = removeCaracteresIgnorados(iESemDigito);
-        }
+		if (iESemDigito.length() == 10) {
+			iESemDigito = removeCaracteresIgnorados(iESemDigito);
+		}
 
-        String digitoCalculado = calculaDigito(iESemDigito);
-        return digito.equals(digitoCalculado);
-    }
+		String digitoCalculado = calculaDigito(iESemDigito);
+		return digito.equals(digitoCalculado);
+	}
 
-    private String removeCaracteresIgnorados(String iESemDigito) {
-        return iESemDigito.substring(0, 2) + iESemDigito.substring(4);
-    }
+	private String removeCaracteresIgnorados(String iESemDigito) {
+		return iESemDigito.substring(0, 2) + iESemDigito.substring(4);
+	}
 
-    private String calculaDigito(String iESemDigito) {
-        return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11).calcula();
-    }
+	private String calculaDigito(String iESemDigito) {
+		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11).calcula();
+	}
 
-    /**
-     * @see Validator#generateRandomValid()
-     * @return uma inscrição estadual válida com 9 dígitos
-     */
-    @Override
-    public String generateRandomValid() {
-        final String ieSemDigito = new DigitoGenerator().generate(8);
-        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-        if (isFormatted) {
-            return format(ieComDigito, "##.###.###-#");
-        }
-        return ieComDigito;
-    }
+	/**
+	 * @see Validator#generateRandomValid()
+	 * @return uma inscrição estadual válida com 9 dígitos
+	 */
+	@Override
+	public String generateRandomValid() {
+		final String ieSemDigito = new DigitoGenerator().generate(8);
+		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+		if (isFormatted) {
+			return format(ieComDigito, "##.###.###-#");
+		}
+		return ieComDigito;
+	}
 }

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IETocantinsValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IETocantinsValidator.java
@@ -1,9 +1,6 @@
 package br.com.caelum.stella.validation.ie;
 
-import java.text.ParseException;
 import java.util.regex.Pattern;
-
-import javax.swing.text.MaskFormatter;
 
 import br.com.caelum.stella.DigitoGenerator;
 import br.com.caelum.stella.DigitoPara;
@@ -84,17 +81,6 @@ public class IETocantinsValidator extends AbstractIEValidator {
 		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11).calcula();
 	}
 
-	private String formata(String valor) {
-		try {
-			final MaskFormatter formatador = new MaskFormatter("##.###.###-#");
-			formatador.setValidCharacters("1234567890");
-			formatador.setValueContainsLiteralCharacters(false);
-			return formatador.valueToString(valor);
-		} catch (ParseException e) {
-			throw new RuntimeException("Valor gerado não bate com o padrão: " + valor, e);
-		}
-	}
-
 	/**
 	 * @see Validator#generateRandomValid()
 	 * @return uma inscrição estadual válida com 9 dígitos
@@ -104,7 +90,7 @@ public class IETocantinsValidator extends AbstractIEValidator {
 		final String ieSemDigito = new DigitoGenerator().generate(8);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return formata(ieComDigito);
+			return format(ieComDigito,"##.###.###-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IETocantinsValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IETocantinsValidator.java
@@ -12,10 +12,11 @@ import br.com.caelum.stella.validation.Validator;
  * <p>
  * Documentação de referência:
  * </p>
- * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_TO.html">SINTEGRA - ROTEIRO
- * DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a> <br>
- * <a href="http://www2.sefaz.to.gov.br/Servicos/Sintegra/calinse.htm"> ESTADO DO
- * TOCANTINS SECRETARIA DA FAZENDA ASSESSORIA DE MODERNIZAÇÃO E INFORMAÇÃO</a>
+ * <a href="http://www.sintegra.gov.br/Cad_Estados/cad_TO.html">SINTEGRA -
+ * ROTEIRO DE CRÍTICA DA INSCRIÇÃO ESTADUAL </a> <br>
+ * <a href="http://www2.sefaz.to.gov.br/Servicos/Sintegra/calinse.htm"> ESTADO
+ * DO TOCANTINS SECRETARIA DA FAZENDA ASSESSORIA DE MODERNIZAÇÃO E
+ * INFORMAÇÃO</a>
  * 
  * @author Leonardo Bessa
  * 
@@ -26,72 +27,70 @@ public class IETocantinsValidator extends AbstractIEValidator {
 
     public static final Pattern UNFORMATED = Pattern.compile("(\\d{9}|\\d{11})");
 
+    /**
+     * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
+     * {@linkplain SimpleMessageProducer} para geração de mensagens.
+     */
+    public IETocantinsValidator() {
+        super(true);
+    }
 
     /**
-	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um
-	 * {@linkplain SimpleMessageProducer} para geração de mensagens.
-	 */
-	public IETocantinsValidator() {
-		super(true);
-	}
+     * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
+     * mensagens.
+     * 
+     * @param isFormatted
+     *            considerar cadeia formatada quando <code>true</code>
+     */
+    public IETocantinsValidator(boolean isFormatted) {
+        super(isFormatted);
+    }
 
-	/**
-	 * O validador utiliza um {@linkplain SimpleMessageProducer} para geração de
-	 * mensagens.
-	 * 
-	 * @param isFormatted
-	 *            considerar cadeia formatada quando <code>true</code>
-	 */
-	public IETocantinsValidator(boolean isFormatted) {
-		super(isFormatted);
-	}
+    public IETocantinsValidator(MessageProducer messageProducer, boolean isFormatted) {
+        super(messageProducer, isFormatted);
+    }
 
-	public IETocantinsValidator(MessageProducer messageProducer, boolean isFormatted) {
-		super(messageProducer, isFormatted);
-	}
+    @Override
+    protected Pattern getUnformattedPattern() {
+        return UNFORMATED;
+    }
 
+    @Override
+    protected Pattern getFormattedPattern() {
+        return FORMATED;
+    }
 
-	@Override
-	protected Pattern getUnformattedPattern() {
-		return UNFORMATED;
-	}
+    protected boolean hasValidCheckDigits(String unformattedIE) {
+        String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
+        String digito = unformattedIE.substring(unformattedIE.length() - 1);
 
-	@Override
-	protected Pattern getFormattedPattern() {
-		return FORMATED;
-	}
-	
-	protected boolean hasValidCheckDigits(String unformattedIE) {
-		String iESemDigito = unformattedIE.substring(0, unformattedIE.length() - 1);
-		String digito = unformattedIE.substring(unformattedIE.length() - 1);
-		
-		if(iESemDigito.length() == 10){
-			iESemDigito = removeCaracteresIgnorados(iESemDigito);
-		}
-		
-		String digitoCalculado = calculaDigito(iESemDigito);
-		return digito.equals(digitoCalculado);
-	}
+        if (iESemDigito.length() == 10) {
+            iESemDigito = removeCaracteresIgnorados(iESemDigito);
+        }
 
-	private String removeCaracteresIgnorados(String iESemDigito) {
-		return iESemDigito.substring(0,2) + iESemDigito.substring(4);
-	}
+        String digitoCalculado = calculaDigito(iESemDigito);
+        return digito.equals(digitoCalculado);
+    }
 
-	private String calculaDigito(String iESemDigito) {
-		return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11).calcula();
-	}
+    private String removeCaracteresIgnorados(String iESemDigito) {
+        return iESemDigito.substring(0, 2) + iESemDigito.substring(4);
+    }
 
-	/**
-	 * @see Validator#generateRandomValid()
-	 * @return uma inscrição estadual válida com 9 dígitos
-	 */
-	@Override
-	public String generateRandomValid() {
-		final String ieSemDigito = new DigitoGenerator().generate(8);
-		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
-		if (isFormatted) {
-			return format(ieComDigito,"##.###.###-#");
-		}
-		return ieComDigito;
-	}
+    private String calculaDigito(String iESemDigito) {
+        return new DigitoPara(iESemDigito).complementarAoModulo().trocandoPorSeEncontrar("0", 10, 11).calcula();
+    }
+
+    /**
+     * @see Validator#generateRandomValid()
+     * @return uma inscrição estadual válida com 9 dígitos
+     */
+    @Override
+    public String generateRandomValid() {
+        final String ieSemDigito = new DigitoGenerator().generate(8);
+        final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
+        if (isFormatted) {
+            return format(ieComDigito, "##.###.###-#");
+        }
+        return ieComDigito;
+    }
 }


### PR DESCRIPTION
Fiz uma refatoração nas validações de ies, reduzindo cerca de 250 linhas duplicadas e sem descaracterizar o ojetivo do código. Basicamente o que fiz foi remover o método formata para a classe herdada. Percebi que a formatação ficou um pouco diferente. Usei a padrão do eclipse(caso seja impeditivo para aceitar o pull request, ficarei no aguardo ou do arquivo de formatação ou das regras para formatar que não achei no projeto)
Fico muito feliz em ajudar este projeto que já me ajudou muito.   