### PR TITLE
Alterado validação da Inscrição Estadual do DF

### DIFF
--- a/examples/faces-example-1x/pom.xml
+++ b/examples/faces-example-1x/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.caelum.stella</groupId>
 		<artifactId>caelum-stella</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>2.1.6-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>faces-example-1x</artifactId>

--- a/examples/faces-example-2x/pom.xml
+++ b/examples/faces-example-2x/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.caelum.stella</groupId>
 		<artifactId>caelum-stella</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>2.1.6-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>faces-example-2x</artifactId>

--- a/examples/hibernate-persistence-example/pom.xml
+++ b/examples/hibernate-persistence-example/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.caelum.stella</groupId>
 		<artifactId>caelum-stella</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>2.1.6-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>hibernate-persistence-example</artifactId>

--- a/examples/vraptor-validator-example/pom.xml
+++ b/examples/vraptor-validator-example/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>br.com.caelum.stella</groupId>
 		<artifactId>caelum-stella</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>2.1.6-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>vraptor-validator-example</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>br.com.caelum.stella</groupId>
   <artifactId>caelum-stella</artifactId>
   <packaging>pom</packaging>
-  <version>2.1.5-SNAPSHOT</version>
+  <version>2.1.6-SNAPSHOT</version>
   <name>Caelum Stella</name>
   <description>
     Caelum Stella is a set of validators, formatters and converters

--- a/stella-bean-validation/pom.xml
+++ b/stella-bean-validation/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>br.com.caelum.stella</groupId>
 		<artifactId>caelum-stella</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>2.1.6-SNAPSHOT</version>
 	</parent>
 	<artifactId>caelum-stella-bean-validation</artifactId>
 	<packaging>jar</packaging>

--- a/stella-boleto/pom.xml
+++ b/stella-boleto/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.caelum.stella</groupId>
 		<artifactId>caelum-stella</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>2.1.6-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>caelum-stella-boleto</artifactId>
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>br.com.caelum.stella</groupId>
 			<artifactId>caelum-stella-core</artifactId>
-			<version>2.1.5-SNAPSHOT</version>
+			<version>2.1.6-SNAPSHOT</version>
 		</dependency>
 
 	    <dependency>

--- a/stella-core/pom.xml
+++ b/stella-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>br.com.caelum.stella</groupId>
     <artifactId>caelum-stella</artifactId>
-    <version>2.1.5-SNAPSHOT</version>
+    <version>2.1.6-SNAPSHOT</version>
   </parent>
   <artifactId>caelum-stella-core</artifactId>
   <packaging>jar</packaging>

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidator.java
@@ -24,9 +24,9 @@ public class IEDistritoFederalValidator extends AbstractIEValidator {
 	 * Formato: 07.408.738/002-50
 	 */
 
-	public static final Pattern FORMATED = Pattern.compile("(07)[.]([3-9]\\d{2})[.](\\d{3})[/](\\d{3})[-](\\d{2})");
+	public static final Pattern FORMATED = Pattern.compile("(07|08)[.]([0-9]\\d{2})[.](\\d{3})[/](\\d{3})[-](\\d{2})");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(07)([3-9]\\d{2})(\\d{3})(\\d{3})(\\d{2})");
+	public static final Pattern UNFORMATED = Pattern.compile("(07|08)([0-9]\\d{2})(\\d{3})(\\d{3})(\\d{2})");
 
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um

--- a/stella-core/src/test/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidatorTest.java
+++ b/stella-core/src/test/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidatorTest.java
@@ -25,8 +25,8 @@ public class IEDistritoFederalValidatorTest extends IEValidatorTest {
 
 	private static final String validFormattedString = "07.408.738/002-50";
 
-	private static final String[] validValues = { validFormattedString, "07.343.623/001-77", "07.451.530/001-68",
-			"07.389.634/001-01", "07.336.802/001-60", "07.346.779/001-46", "07.548.137/001-52", "07.300.001/001-09" };
+	private static final String[] validValues = { validFormattedString, "07.343.623/001-77", "07.451.530/001-68", "07.389.634/001-01",
+			"07.336.802/001-60", "07.346.779/001-46", "07.548.137/001-52", "07.300.001/001-09", "08.006.816/001-02" };
 
 	public IEDistritoFederalValidatorTest() {
 		super(wrongFirstCheckDigitUnformattedString, validUnformattedString, validFormattedString, validValues);

--- a/stella-faces/pom.xml
+++ b/stella-faces/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.caelum.stella</groupId>
 		<artifactId>caelum-stella</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>2.1.6-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>caelum-stella-faces</artifactId>

--- a/stella-frete/pom.xml
+++ b/stella-frete/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>br.com.caelum.stella</groupId>
     <artifactId>caelum-stella</artifactId>
-    <version>2.1.5-SNAPSHOT</version>
+    <version>2.1.6-SNAPSHOT</version>
   </parent>
   
   <artifactId>caelum-stella-frete</artifactId>

--- a/stella-hibernate-user-types/pom.xml
+++ b/stella-hibernate-user-types/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>br.com.caelum.stella</groupId>
 		<artifactId>caelum-stella</artifactId>
-		<version>2.1.5-SNAPSHOT</version>
+		<version>2.1.6-SNAPSHOT</version>
 	</parent>
 	<artifactId>caelum-stella-hibernate-user-types</artifactId>
 	<packaging>jar</packaging>


### PR DESCRIPTION
**O que foi feito**
* Alterado validação da Inscrição Estadual do DF

**Motivo disso ter sido feito**
A numeração da IE disponibilizada pelo estado de DF esgotou-se. Sendo que a partir de agosto as numerações geradas inciam-se com 08.


![screenshot-nimbusweb me-2020 11 30-17_42_30](https://user-images.githubusercontent.com/29982867/100662555-d2ec9200-3333-11eb-8cca-d88e9f0513d1.png)



**Links**
https://github.com/caelum/caelum-stella/issues/267