### PR TITLE
Atualização da regra de validação de IE para o Distrito Federal

### DIFF
--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidator.java
@@ -24,9 +24,9 @@ public class IEDistritoFederalValidator extends AbstractIEValidator {
 	 * Formato: 07.408.738/002-50
 	 */
 
-	public static final Pattern FORMATED = Pattern.compile("(07)[.]([3-9]\\d{2})[.](\\d{3})[/](\\d{3})[-](\\d{2})");
+	public static final Pattern FORMATED = Pattern.compile("(0[7-8])[.]([0-9]\\d{2})[.](\\d{3})[/](\\d{3})[-](\\d{2})");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(07)([3-9]\\d{2})(\\d{3})(\\d{3})(\\d{2})");
+	public static final Pattern UNFORMATED = Pattern.compile("(0[7-8])([0-9]\\d{2})(\\d{3})(\\d{3})(\\d{2})");
 
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um

--- a/stella-core/src/test/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidatorTest.java
+++ b/stella-core/src/test/java/br/com/caelum/stella/validation/ie/IEDistritoFederalValidatorTest.java
@@ -25,8 +25,15 @@ public class IEDistritoFederalValidatorTest extends IEValidatorTest {
 
 	private static final String validFormattedString = "07.408.738/002-50";
 
-	private static final String[] validValues = { validFormattedString, "07.343.623/001-77", "07.451.530/001-68",
-			"07.389.634/001-01", "07.336.802/001-60", "07.346.779/001-46", "07.548.137/001-52", "07.300.001/001-09" };
+	private static final String[] validValues = {
+			validFormattedString, "07.343.623/001-77", "07.451.530/001-68",
+			"07.389.634/001-01", "07.336.802/001-60", "07.346.779/001-46", "07.548.137/001-52", "07.300.001/001-09",
+			"07.049.826/001-24", "07.227.366/001-03", "07.803.364/001-39", "07.729.081/001-77", "07.327.328/001-05",
+			"07.212.337/001-69", "07.467.791/001-42", "07.590.178/001-66", "07.756.805/001-93", "07.222.083/001-85",
+			"07.862.867/001-68", "07.421.535/001-82", "07.110.853/001-87", "07.034.188/001-02", "07.948.231/001-90",
+			"08.421.635/001-90", "08.421.575/001-32", "08.491.535/001-86", "08.821.535/001-88", "08.422.535/001-80"
+
+	};
 
 	public IEDistritoFederalValidatorTest() {
 		super(wrongFirstCheckDigitUnformattedString, validUnformattedString, validFormattedString, validValues);


### PR DESCRIPTION
Correção da REGEX de validação de inscrição estadual para o Distrito Federal (DF), devido ao esgotamento da sequência do mesmo, houve alteração do início da I.E. que era 07 e passou a ser 08. Também foi incrementado os inputs de teste unitários para o cenário corrigido.

Issue https://github.com/caelum/caelum-stella/issues/269