### PR TITLE
Atualizando Regex para aceitar hifen

### DIFF
--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioDeJaneiroValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioDeJaneiroValidator.java
@@ -9,7 +9,7 @@ import br.com.caelum.stella.SimpleMessageProducer;
 
 public class IERioDeJaneiroValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3}){2}");
+	public static final Pattern FORMATED = Pattern.compile("\\d{2}(\\.\\d{3})\\.\\d{2}\\-\\d");
 
 	public static final Pattern UNFORMATED = Pattern.compile("\\d{8}");
 
@@ -67,7 +67,7 @@ public class IERioDeJaneiroValidator extends AbstractIEValidator {
 		final String ieSemDigito = new DigitoGenerator().generate(7);
 		final String ieComDigito = ieSemDigito + calculaDigito(ieSemDigito);
 		if (isFormatted) {
-			return super.format(ieComDigito, "##.###.###");
+			return super.format(ieComDigito, "##.###.##-#");
 		}
 		return ieComDigito;
 	}

--- a/stella-core/src/test/java/br/com/caelum/stella/validation/ie/IERioDeJaneiroValidatorTest.java
+++ b/stella-core/src/test/java/br/com/caelum/stella/validation/ie/IERioDeJaneiroValidatorTest.java
@@ -9,13 +9,13 @@ public class IERioDeJaneiroValidatorTest extends IEValidatorTest {
 		super(wrongCheckDigitUnformattedString, validUnformattedString, validFormattedString, validValues);
 	}
 
-	private static final String validFormattedString = "78.045.302";
-	
+	private static final String validFormattedString = "78.045.30-2";
+		
 	private static final String validUnformattedString = "78045302";
 	
 	private static final String wrongCheckDigitUnformattedString = "78045304";
 	
-	private static final String[] validValues = { validFormattedString, "53.518.028", "71.294.242" };
+	private static final String[] validValues = { validFormattedString, "53.518.02-8", "71.294.24-2" };
 
 	@Override
 	protected Validator<String> getValidator(MessageProducer messageProducer, boolean isFormatted) {


### PR DESCRIPTION
A inscrição estadual do Rio de Janeiro não estava aceitando hífen no digito verificador!