### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ before_install:
 
 script:
 - mvn test verify --batch-mode
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

If there are any inappropriate modifications in this PR, please give me feedback and I will change them.
