### PR TITLE
Alteração Validação IE estado de Goiás

### DIFF
--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEGoiasValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEGoiasValidator.java
@@ -94,7 +94,7 @@ public class IEGoiasValidator extends AbstractIEValidator {
 
 	@Override
 	public String generateRandomValid() {
-		final int[] segundoDigitosPossiveis = new int[] { 0, 1, 5 };
+		final int[] segundoDigitosPossiveis = new int[] { 0, 1, 9 };
 		final int segundoDigitoSorteado = new Random().nextInt(segundoDigitosPossiveis.length);
 		final String ieSemDigito = "1" + segundoDigitosPossiveis[segundoDigitoSorteado]
 				+ new DigitoGenerator().generate(6);

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEGoiasValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEGoiasValidator.java
@@ -22,9 +22,9 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEGoiasValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("(1[015])[.](\\d{3})[.](\\d{3})[-](\\d{1})");
+    	public static final Pattern FORMATED = Pattern.compile("([12][019])[.](\\d{3})[.](\\d{3})[-](\\d{1})");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(1[015])(\\d{3})(\\d{3})(\\d{1})");
+    	public static final Pattern UNFORMATED = Pattern.compile("([12][019])(\\d{3})(\\d{3})(\\d{1})");
 
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um

--- a/stella-core/src/test/java/br/com/caelum/stella/validation/ie/IEGoiasValidatorTest.java
+++ b/stella-core/src/test/java/br/com/caelum/stella/validation/ie/IEGoiasValidatorTest.java
@@ -16,7 +16,7 @@ public class IEGoiasValidatorTest extends IEValidatorTest {
 
     private static final String validFormattedString = "10.987.654-7";
 
-    private static final String[] validValues = { validFormattedString, "10.103.119-1", "15.368.273-6" };
+    private static final String[] validValues = { validFormattedString, "10.103.119-1", "20.003.152-0" };
 
 	@Override
 	protected Validator<String> getValidator(MessageProducer messageProducer, boolean isFormatted) {


### PR DESCRIPTION
Goiás mudou a forma de calcular.

Formato da Inscrição: AB.CDE.FGH-I
8 dígitos (ABCDEFGH) + 1 dígito verificador (I); onde AB pode ser igual a 10 ou 11 ou 20 a 29.

http://www.sintegra.gov.br/Cad_Estados/cad_GO.html

Precisa gerar novo release no MAVEN