### PR TITLE
Enable auto publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+
     steps:
       - uses: actions/checkout@v4
       - name: Setup Java JDK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Java CI
-on: [push]
+on:
+  push:
+    branches:
+      - master
+
 env:
   MAVEN_OPTS: -Dmaven.artifact.threads=256 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 jobs:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,5 +1,9 @@
 name: Pull Request
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+    - master
+
 env:
   MAVEN_OPTS: -Dmaven.artifact.threads=256 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 jobs:

--- a/.github/workflows/sonatype-publish.yml
+++ b/.github/workflows/sonatype-publish.yml
@@ -45,5 +45,7 @@ jobs:
           gpg-key: ${{ secrets.GPG_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }} 
 
+          release-branch-name: "enable-auto-publish"
+
       - name: 'Remove Snapshots Before Caching'
         run: find ~/.m2 -name '*SNAPSHOT' | xargs rm -Rf

--- a/.github/workflows/sonatype-publish.yml
+++ b/.github/workflows/sonatype-publish.yml
@@ -37,7 +37,8 @@ jobs:
           git-release-bot-name: "bot-release"
           git-release-bot-email: "release@caelum.com.br"
 
-          maven-args: "-DskipTests -DskipITs -Dmaven.deploy.skip=true -PsonatypeDeploy"
+          maven-args: "-DskipTests -PsonatypeDeploy"
+          maven-servers: ${{ secrets.MVN_REPO_SERVERS }}
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
           gpg-enabled: true

--- a/.github/workflows/sonatype-publish.yml
+++ b/.github/workflows/sonatype-publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Cache Maven packages'
         uses: actions/cache@v4

--- a/.github/workflows/sonatype-publish.yml
+++ b/.github/workflows/sonatype-publish.yml
@@ -2,9 +2,6 @@ name: Maven Release
 
 on:
   workflow_dispatch:
-  push:
-  release:
-    types: [ created ]
 
 jobs:
   publish:
@@ -45,8 +42,6 @@ jobs:
           gpg-key-id: ${{ secrets.GPG_KEY_ID }}
           gpg-key: ${{ secrets.GPG_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }} 
-
-          release-branch-name: "enable-auto-publish"
 
       - name: 'Remove Snapshots Before Caching'
         run: find ~/.m2 -name '*SNAPSHOT' | xargs rm -Rf

--- a/.github/workflows/sonatype-publish.yml
+++ b/.github/workflows/sonatype-publish.yml
@@ -1,0 +1,49 @@
+name: Maven Release
+
+on:
+  workflow_dispatch:
+  push:
+  release:
+    types: [ created ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: 'cache'
+          restore-keys: 'cache'
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: 'Build with Maven'
+        run: mvn -B install --file pom.xml
+
+      - name: Release
+        uses: qcastel/github-actions-maven-release@master
+        env:
+          JAVA_HOME: /usr/lib/jvm/java-11-openjdk/
+        with:
+          git-release-bot-name: "bot-release"
+          git-release-bot-email: "release@caelum.com.br"
+
+          maven-args: "-DskipTests -DskipITs -Dmaven.deploy.skip=true -Psonatype-oss-release"
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+          gpg-enabled: true
+          gpg-key-id: ${{ secrets.GPG_KEY_ID }}
+          gpg-key: ${{ secrets.GPG_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }} 
+
+      - name: 'Remove Snapshots Before Caching'
+        run: find ~/.m2 -name '*SNAPSHOT' | xargs rm -Rf

--- a/.github/workflows/sonatype-publish.yml
+++ b/.github/workflows/sonatype-publish.yml
@@ -37,7 +37,7 @@ jobs:
           git-release-bot-name: "bot-release"
           git-release-bot-email: "release@caelum.com.br"
 
-          maven-args: "-DskipTests -DskipITs -Dmaven.deploy.skip=true -Psonatype-oss-release"
+          maven-args: "-DskipTests -DskipITs -Dmaven.deploy.skip=true -PsonatypeDeploy"
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
           gpg-enabled: true

--- a/.github/workflows/sonatype-publish.yml
+++ b/.github/workflows/sonatype-publish.yml
@@ -31,8 +31,8 @@ jobs:
         env:
           JAVA_HOME: /usr/lib/jvm/java-11-openjdk/
         with:
-          git-release-bot-name: "bot-release"
-          git-release-bot-email: "release@caelum.com.br"
+          git-release-bot-name: "angeliski"
+          git-release-bot-email: "angeliski@hotmail.com"
 
           maven-args: "-DskipTests -PsonatypeDeploy"
           maven-servers: ${{ secrets.MVN_REPO_SERVERS }}

--- a/pom.xml
+++ b/pom.xml
@@ -454,15 +454,15 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.3.0</version>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.7</version>
             <extensions>true</extensions>
             <configuration>
-              <publishingServerId>central</publishingServerId>
-              <tokenAuth>true</tokenAuth>
-              <autoPublish>true</autoPublish>
-              <waitUntil>published</waitUntil>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <!-- we need to release from staging to avoid errors and ensure double check -->
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
             </configuration>
           </plugin>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,14 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>3.1.1</version>
+          <configuration>
+            <scmCommentPrefix>[ci skip]</scmCommentPrefix>
+            <tagNameFormat>@{project.version}</tagNameFormat>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -433,6 +441,72 @@
             </plugin>
           </plugins>
         </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <!-- required, used in .github/workflows/sonatype-publish.yml -->
+      <id>sonatypeDeploy</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.3.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <tokenAuth>true</tokenAuth>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.3.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.6.3</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -446,6 +446,11 @@
     <profile>
       <!-- required, used in .github/workflows/sonatype-publish.yml -->
       <id>sonatypeDeploy</id>
+      <properties>
+        <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+        <gpg.keyname>${env.GPG_KEY_ID}</gpg.keyname>
+        <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -459,19 +464,6 @@
               <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
             </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>3.3.0</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
# Descrição
Esse PR modifica os workflows para facilitar a publicação de uma nova versão. Agora é possivel via Actions disparar um fluxo para o release. A versão será publicada em staging e será necessário liberar o release no Nexus, isso para garantir que não haja nenhum acidente na liberação.
Inicialmente o fluxo seria controlado via Release do GH, mas devido a limitações da estrutura eu decidi utilizar apenas o trigger normal, no futuro isso pode ser revisto.


As credencias cadastradas são todas minhas, para facilitar o fluxo. Se necessário isso pode ser alterado para uma machine account.


Ref:
https://itnext.io/publishing-artifacts-to-maven-central-using-github-actions-a-step-by-step-guide-fd65ef075fd4
https://github.com/marketplace/actions/java-maven-release
https://github.com/teamlead/java-maven-sonatype-starter?tab=readme-ov-file