### PR TITLE
Adicionando novos dígitos na validação IE Pará

### DIFF
--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaValidator.java
@@ -18,9 +18,9 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEParaValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("(15|75|76|77|78|79)(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("(15|7[5-9])(\\.\\d{3}){2}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("(15|75|76|77|78|79)\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("(15|7[5-9])\\d{7}");
 
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IEParaValidator.java
@@ -18,9 +18,9 @@ import br.com.caelum.stella.SimpleMessageProducer;
  */
 public class IEParaValidator extends AbstractIEValidator {
 
-	public static final Pattern FORMATED = Pattern.compile("15(\\.\\d{3}){2}\\-\\d{1}");
+	public static final Pattern FORMATED = Pattern.compile("(15|75|76|77|78|79)(\\.\\d{3}){2}\\-\\d{1}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("15\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("(15|75|76|77|78|79)\\d{7}");
 
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um


### PR DESCRIPTION
Adicionando novos dígitos na validação de IE Pará. Seguindo alteraçõs conforme http://www.sintegra.gov.br/Cad_Estados/cad_PA.html