### PR TITLE
Adicionado novos prefixos na validação de IE do Rio Grande do Sul

### DIFF
--- a/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoSulValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/ie/IERioGrandeDoSulValidator.java
@@ -18,9 +18,9 @@ public class IERioGrandeDoSulValidator extends AbstractIEValidator {
 
 	private final boolean isFormatted;
 
-	public static final Pattern FORMATED = Pattern.compile("[0-4]\\d{2}\\/\\d{7}");
+	public static final Pattern FORMATED = Pattern.compile("([0-4]\\d{2}|800|900)\\/\\d{7}");
 
-	public static final Pattern UNFORMATED = Pattern.compile("([0-4]\\d{2})\\d{7}");
+	public static final Pattern UNFORMATED = Pattern.compile("([0-4]\\d{2}|800|900)\\d{7}");
 
 	/**
 	 * Este considera, por padrão, que as cadeias estão formatadas e utiliza um

--- a/stella-core/src/test/java/br/com/caelum/stella/validation/ie/IERioGrandeDoSulValidatorTest.java
+++ b/stella-core/src/test/java/br/com/caelum/stella/validation/ie/IERioGrandeDoSulValidatorTest.java
@@ -12,8 +12,15 @@ public class IERioGrandeDoSulValidatorTest extends IEValidatorTest {
 	private static final String validFormattedString = "224/3658792";
 	private static final String validUnformattedString = "2243658792";
 	private static final String wrongCheckDigitUnformattedString = "2243658791";
-	
-	private static final String[] validValues = { validFormattedString, "050/0068836", "224/3224326", "468/0001479" };
+
+  private static final String[] validValues = {
+    validFormattedString,
+    "050/0068836",
+    "224/3224326",
+    "468/0001479",
+    "800/1234507",
+    "900/5678939"
+  };
 
 	@Override
 	protected Validator<String> getValidator(MessageProducer messageProducer, boolean isFormatted) {


### PR DESCRIPTION
* Alterado conforme últimas alterações na "Instrução Normativa DRP Nº 45 DE 26/10/1998"

* Prefixo 800 conforme subitem 1.2.3.3 acrescentado pela "Instrução Normativa RE Nº 87 DE 11/09/2024"

* Prefixo 900 conforme subitem 1.2.3.2 acrescentado pela "Instrução Normativa RE Nº 1 DE 06/01/2016"

* fix #297