### PR TITLE
[FIX]: Uso de dígitos verificadores alfanuméricos no CNPJ

### DIFF
--- a/stella-core/src/main/java/br/com/caelum/stella/format/CNPJFormatter.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/format/CNPJFormatter.java
@@ -10,7 +10,7 @@ public class CNPJFormatter implements Formatter {
     private final BaseFormatter base;
 
     public CNPJFormatter() {
-        this.base = new BaseFormatter(CNPJValidator.FORMATED, "$1.$2.$3/$4-$5", CNPJValidator.UNFORMATED, "$1$2$3$4$5");
+        this.base = new BaseFormatter(CNPJValidator.FORMATTED, "$1.$2.$3/$4-$5", CNPJValidator.UNFORMATTED, "$1$2$3$4$5");
     }
 
     @Override

--- a/stella-core/src/main/java/br/com/caelum/stella/validation/CNPJValidator.java
+++ b/stella-core/src/main/java/br/com/caelum/stella/validation/CNPJValidator.java
@@ -19,10 +19,10 @@ import br.com.caelum.stella.validation.error.CNPJError;
  */
 public class CNPJValidator implements Validator<String> {
 
-    public static final Pattern FORMATED = Pattern.compile(
-            "([0-9A-Z]{2})[.]([0-9A-Z]{3})[.]([0-9A-Z]{3})/([0-9A-Z]{4})-([0-9A-Z]{2})");
-    public static final Pattern UNFORMATED = Pattern.compile(
-            "([0-9A-Z]{2})([0-9A-Z]{3})([0-9A-Z]{3})([0-9A-Z]{4})([0-9A-Z]{2})");
+    public static final Pattern FORMATTED = Pattern.compile(
+            "([0-9A-Z]{2})[.]([0-9A-Z]{3})[.]([0-9A-Z]{3})/([0-9A-Z]{4})-([0-9]{2})");
+    public static final Pattern UNFORMATTED = Pattern.compile(
+            "([0-9A-Z]{2})([0-9A-Z]{3})([0-9A-Z]{3})([0-9A-Z]{4})([0-9]{2})");
 	
     private boolean isFormatted = false;
     private boolean isIgnoringRepeatedDigits;
@@ -88,7 +88,7 @@ public class CNPJValidator implements Validator<String> {
         
         if (cnpj != null) {
 
-        	if(isFormatted != FORMATED.matcher(cnpj).matches()) {
+        	if(isFormatted != FORMATTED.matcher(cnpj).matches()) {
         		errors.add(messageProducer.getMessage(CNPJError.INVALID_FORMAT));
         	}
         	
@@ -143,9 +143,9 @@ public class CNPJValidator implements Validator<String> {
 		}
         boolean result;
         if (isFormatted) {
-            result = FORMATED.matcher(value).matches();
+            result = FORMATTED.matcher(value).matches();
         } else {
-            result = UNFORMATED.matcher(value).matches();
+            result = UNFORMATTED.matcher(value).matches();
         }
         return result;
     }

--- a/stella-core/src/test/java/br/com/caelum/stella/validation/CNPJValidatorTest.java
+++ b/stella-core/src/test/java/br/com/caelum/stella/validation/CNPJValidatorTest.java
@@ -237,4 +237,22 @@ public class CNPJValidatorTest {
         final String generated = cnpjValidator.generateRandomValid();
         cnpjValidator.assertValid(generated);
     }
+
+    @Test
+    public void shouldNotMatchAlphanumericDv(){
+        final String formattedCNPJWithInvalidDv = "12.ABC.345/01DE-9B";
+        final String unformattedCNPJWithInvalidDv = "12ABC34501DE9B";
+
+        assertFalse( CNPJValidator.FORMATTED.matcher( formattedCNPJWithInvalidDv ).matches() );
+        assertFalse( CNPJValidator.UNFORMATTED.matcher( unformattedCNPJWithInvalidDv ).matches() );
+    }
+
+    @Test
+    public void shouldMatchNumericDv(){
+        final String formattedCNPJWithInvalidDv = "12.ABC.345/01DE-35";
+        final String unformattedCNPJWithInvalidDv = "12ABC34501DE35";
+
+        assertTrue( CNPJValidator.FORMATTED.matcher( formattedCNPJWithInvalidDv ).matches() );
+        assertTrue( CNPJValidator.UNFORMATTED.matcher( unformattedCNPJWithInvalidDv ).matches() );
+    }
 }

--- a/stella-core/src/test/java/br/com/caelum/stella/validation/CNPJValidatorTest.java
+++ b/stella-core/src/test/java/br/com/caelum/stella/validation/CNPJValidatorTest.java
@@ -249,10 +249,10 @@ public class CNPJValidatorTest {
 
     @Test
     public void shouldMatchNumericDv(){
-        final String formattedCNPJWithInvalidDv = "12.ABC.345/01DE-35";
-        final String unformattedCNPJWithInvalidDv = "12ABC34501DE35";
+        final String formattedCNPJWithValidDv = "12.ABC.345/01DE-35";
+        final String unformattedCNPJWithValidDv = "12ABC34501DE35";
 
-        assertTrue( CNPJValidator.FORMATTED.matcher( formattedCNPJWithInvalidDv ).matches() );
-        assertTrue( CNPJValidator.UNFORMATTED.matcher( unformattedCNPJWithInvalidDv ).matches() );
+        assertTrue( CNPJValidator.FORMATTED.matcher( formattedCNPJWithValidDv ).matches() );
+        assertTrue( CNPJValidator.UNFORMATTED.matcher( unformattedCNPJWithValidDv ).matches() );
     }
 }


### PR DESCRIPTION
Ajustada a expressão regular para impedir caracteres alfanuméricos no DV, garantindo maior conformidade com a regra oficial de validação. Visto que o dígito verificador do CNPJ deve ser sempre numérico. 